### PR TITLE
Add Seaways MPSS marketing landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# The-Whole-Hole
-This is where stuff goes to get lost
+# Seaways MPSS
+
+Marketing landing page for **Seaways MPSS** — LANG's **Multi-Purpose Semi-Submersible**,
+a validated, standardized deepwater production host built on a five-S design philosophy:
+**Simple · Safe · Swift · Size · Saves.** The site positions the MPSS as pre-positioned,
+leaseable offshore infrastructure that compresses the timeline from FID to first production.
+
+## Structure
+
+| File | Purpose |
+|------|---------|
+| `index.html` | The full single-page site (hero, the MPSS, the Five S, specs, the model, heritage, leasing, contact). |
+| `styles.css` | All styling. Navy / ocean-blue / steel palette; fully responsive. |
+| `main.js`   | Mobile nav toggle and footer year. The site works without JS. |
+
+## Running locally
+
+It's a static site — open `index.html` in a browser, or serve the folder:
+
+```bash
+python3 -m http.server 8000
+# then visit http://localhost:8000
+```
+
+## Deploying
+
+Any static host works (GitHub Pages, Netlify, Cloudflare Pages, S3, etc.).
+For the `seaways-mpss.com` domain, point the host at this repository / folder.
+
+## Content notes
+
+- **Contact details** — search `index.html` for `info@seaways-mpss.com` and update the
+  email; add phone/address in the `#contact` section as needed.
+- **Copy** lives inline in `index.html`, grouped by clearly-commented sections.
+- Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no
+  third-party chart images), so they're safe to edit and reuse.
+- Key figures (15,000 t payload, 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,
+  ~14-month hull delivery, LR/ABS/DNV approval) and the design heritage are drawn from
+  Seaways Engineering source material.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For the `seaways-mpss.com` domain, point the host at this repository / folder.
 
 ## Content notes
 
-- **Contact details** — search `index.html` for `info@seaways-mpss.com` and update the
+- **Contact details** — search `index.html` for `stewart.lang@seaways-mpss.com` and update the
   email; add phone/address in the `#contact` section as needed.
 - **Copy** lives inline in `index.html`, grouped by clearly-commented sections.
 - Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no

--- a/index.html
+++ b/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Seaways MPSS — The Multi-Purpose Semi-Submersible</title>
+  <meta name="description" content="LANG's MPSS is a validated, standardized Multi-Purpose Semi-Submersible: a five-S design — Simple, Safe, Swift, Size, Saves. A 15,000-tonne-payload deepwater production host, approved by Lloyd's Register, ABS and DNV, that turns the floating host from a bespoke project into leaseable offshore infrastructure." />
+  <meta name="theme-color" content="#0a1a2f" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Seaways MPSS — The Multi-Purpose Semi-Submersible" />
+  <meta property="og:description" content="A simple, safe, swift, sizeable and cost-saving deepwater production host. LANG's MPSS turns the floating host from a project bottleneck into pre-positioned offshore infrastructure." />
+  <meta property="og:url" content="https://seaways-mpss.com/" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a1a2f'/%3E%3Cpath d='M4 20h24M8 20v-6h16v6M13 14V9h6v5' stroke='%232ea3d9' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
+</head>
+<body>
+  <!-- ===================== HEADER ===================== -->
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a href="#top" class="brand" aria-label="Seaways MPSS home">
+        <svg class="brand-mark" viewBox="0 0 32 32" width="34" height="34" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#0a1a2f"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="brand-text">Seaways<span class="brand-accent"> MPSS</span></span>
+      </a>
+
+      <nav class="site-nav" aria-label="Primary">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul id="nav-menu" class="nav-menu">
+          <li><a href="#about">The MPSS</a></li>
+          <li><a href="#five-s">The Five S</a></li>
+          <li><a href="#specs">Specs</a></li>
+          <li><a href="#model">The Model</a></li>
+          <li><a href="#heritage">Heritage</a></li>
+          <li><a href="#contact" class="nav-cta">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- ===================== HERO ===================== -->
+    <section class="hero">
+      <div class="hero-bg" aria-hidden="true">
+        <svg class="hero-platform" viewBox="0 0 1200 520" preserveAspectRatio="xMidYMax meet" role="img" aria-label="Illustration of a Multi-Purpose Semi-Submersible production platform">
+          <defs>
+            <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#dbe5ee"/>
+              <stop offset="1" stop-color="#8ea6bd"/>
+            </linearGradient>
+            <linearGradient id="deckG" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#f2f6fb"/>
+              <stop offset="1" stop-color="#c3d2e2"/>
+            </linearGradient>
+            <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#12507a"/>
+              <stop offset="1" stop-color="#0a2c47"/>
+            </linearGradient>
+          </defs>
+
+          <rect x="0" y="360" width="1200" height="160" fill="url(#sea)"/>
+          <path d="M0 372 Q 150 362 300 372 T 600 372 T 900 372 T 1200 372" fill="none" stroke="#2ea3d9" stroke-opacity="0.35" stroke-width="2"/>
+          <path d="M0 392 Q 150 384 300 392 T 600 392 T 900 392 T 1200 392" fill="none" stroke="#2ea3d9" stroke-opacity="0.2" stroke-width="2"/>
+
+          <!-- ring pontoon (deep draft) -->
+          <rect x="358" y="392" width="484" height="34" rx="12" fill="#0e3a5c"/>
+          <!-- columns -->
+          <rect x="392" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="512" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="642" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="762" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <!-- deck box (buoyant) -->
+          <rect x="356" y="268" width="488" height="36" rx="6" fill="url(#deckG)"/>
+          <rect x="356" y="264" width="488" height="8" rx="4" fill="#9fb4c8"/>
+          <!-- topside modules (skid-on) -->
+          <rect x="392" y="224" width="72" height="44" rx="3" fill="#c9d7e6"/>
+          <rect x="482" y="206" width="82" height="62" rx="3" fill="#dbe6f1"/>
+          <rect x="584" y="232" width="60" height="36" rx="3" fill="#c9d7e6"/>
+          <!-- derrick -->
+          <path d="M662 268 L678 166 L694 268 Z" fill="none" stroke="#aebfd1" stroke-width="4"/>
+          <line x1="670" y1="218" x2="686" y2="218" stroke="#aebfd1" stroke-width="3"/>
+          <line x1="666" y1="243" x2="690" y2="243" stroke="#aebfd1" stroke-width="3"/>
+          <!-- flare -->
+          <rect x="728" y="220" width="14" height="48" fill="#b9c9d9"/>
+          <circle cx="735" cy="214" r="8" fill="#ff8a3d" opacity="0.85"/>
+          <!-- mooring / SCR lines -->
+          <line x1="378" y1="404" x2="150" y2="500" stroke="#0e3a5c" stroke-width="3" stroke-opacity="0.7"/>
+          <line x1="822" y1="404" x2="1050" y2="500" stroke="#0e3a5c" stroke-width="3" stroke-opacity="0.7"/>
+        </svg>
+      </div>
+
+      <div class="container hero-content">
+        <p class="eyebrow">LANG's MPSS · Multi-Purpose Semi-Submersible</p>
+        <h1>Simple. Safe. Swift. Size. <span class="grad">Saves.</span></h1>
+        <p class="hero-sub">
+          A validated, standardized deepwater production host built with proven ship-building technology.
+          The MPSS is <strong>a cost-effective solution for working in the ocean — regardless of the work,
+          or the ocean.</strong> It turns the floating host from a bespoke project into pre-positioned,
+          leaseable offshore infrastructure.
+        </p>
+        <div class="hero-actions">
+          <a href="#five-s" class="btn btn-primary">The five-S design</a>
+          <a href="#contact" class="btn btn-ghost">Talk to us</a>
+        </div>
+        <ul class="hero-stats">
+          <li><span class="stat-num">15,000 t</span><span class="stat-label">deck payload</span></li>
+          <li><span class="stat-num">8,100 m²</span><span class="stat-label">open deck</span></li>
+          <li><span class="stat-num">14 months</span><span class="stat-label">hull delivery</span></li>
+          <li><span class="stat-num">LR · ABS · DNV</span><span class="stat-label">approved</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ===================== ABOUT ===================== -->
+    <section class="section" id="about">
+      <div class="container">
+        <p class="section-eyebrow">The MPSS</p>
+        <h2 class="section-title">Not new technology — proven technology, applied properly.</h2>
+        <p class="lead">
+          The Multi-Purpose Semi-Submersible uses standard ship-building methods: uniform box construction
+          in stiffened mild-steel plate, assembled as pontoon, columns and a buoyant deck box with
+          right-angle joints that are simple to weld and easy to inspect. It is less complex than other
+          semi-submersibles, with excellent structural continuity — and it has been through extensive
+          R&amp;D, tank testing and independent classification review.
+        </p>
+
+        <div class="cards cards-3">
+          <article class="card">
+            <h3>A standard hull, any mission</h3>
+            <p>The same validated hull is adapted by its topside package — drilling, production, storage,
+              accommodation or construction support. One design; many jobs.</p>
+          </article>
+          <article class="card">
+            <h3>Independently classed</h3>
+            <p>Approved by Lloyd's Register, the American Bureau of Shipping and DNV — covering primary
+              structure, intact &amp; damaged stability, mooring and ballast systems.</p>
+          </article>
+          <article class="card">
+            <h3>Low-motion by design</h3>
+            <p>A deep-draft ring pontoon sees roughly 40% of surface wave height at 27 m, giving very low
+              heave response — effectively motionless in sub-12&nbsp;m seas.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== FIVE S ===================== -->
+    <section class="section section-alt" id="five-s">
+      <div class="container">
+        <p class="section-eyebrow">The Design Philosophy</p>
+        <h2 class="section-title">The Five S.</h2>
+        <p class="lead">Every advantage of the MPSS traces back to five principles.</p>
+
+        <div class="five-s">
+          <article class="s-card">
+            <span class="s-letter">S</span>
+            <h3>Simple</h3>
+            <p>Modular, panel-line fabrication using common shipyard practice. Standard mild steel, no exotic
+              procedures. Single operating draft with simple ballast and trim systems. Right-angle joints are
+              accessible and easy to inspect.</p>
+          </article>
+          <article class="s-card">
+            <span class="s-letter">S</span>
+            <h3>Safe</h3>
+            <p>A massive reserve of buoyancy — a "safety belt" of ballast at sea level. Watertight subdivision
+              throughout and inherent flood-damage capability. Tested to a 37.5&nbsp;m (123&nbsp;ft) storm wave with
+              no water on deck, no emergency draft, and broken-mooring survival.</p>
+          </article>
+          <article class="s-card">
+            <span class="s-letter">S</span>
+            <h3>Swift</h3>
+            <p>A modular panel-line design means a hull delivered in about 14 months. Quality assurance is
+              straightforward, and prefabricated topside modules skid on before deck assembly — enabling fast
+              turnaround during retrofit.</p>
+          </article>
+          <article class="s-card">
+            <span class="s-letter">S</span>
+            <h3>Size</h3>
+            <p>In the ocean, bigger is better. Bigger is more stable, holds more, stores more oil, and can be
+              reconfigured. Ample deck and stability margin support steel catenary risers and dry trees.</p>
+          </article>
+          <article class="s-card s-card-wide">
+            <span class="s-letter">S</span>
+            <h3>Saves</h3>
+            <p>Low initial cost, low maintenance and low operating cost through standardized box construction —
+              plus high residual value. The sooner it's built, the sooner it makes money.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== SPECS ===================== -->
+    <section class="section section-dark" id="specs">
+      <div class="container">
+        <p class="section-eyebrow light">By the Numbers</p>
+        <h2 class="section-title light">A big, stable, capable platform.</h2>
+        <p class="lead light">Specifications for the reference MPSS host.</p>
+
+        <div class="specs-grid">
+          <div class="spec"><span class="spec-num">15,000<small>t</small></span><span class="spec-label">Deck payload, 5&nbsp;m above deck — deck weight not counted</span></div>
+          <div class="spec"><span class="spec-num">8,100<small>m²</small></span><span class="spec-label">Large, open, uncrowded deck</span></div>
+          <div class="spec"><span class="spec-num">2M<small>bbl</small></span><span class="spec-label">Optional onboard oil storage (SWIS configuration)</span></div>
+          <div class="spec"><span class="spec-num">37.5<small>m</small></span><span class="spec-label">Survival wave tested — 123&nbsp;ft, no water on deck</span></div>
+          <div class="spec"><span class="spec-num">14<small>mo</small></span><span class="spec-label">Estimated hull delivery time</span></div>
+          <div class="spec"><span class="spec-num">1<small>draft</small></span><span class="spec-label">Single operating draft — constant production</span></div>
+        </div>
+
+        <ul class="spec-notes">
+          <li>Steel Catenary Riser (SCR) system — dry-tree capable, longer life, lower cost than flexible hose</li>
+          <li>Skid-on / skid-off topsides — reconfigurable for changing field needs</li>
+          <li>Seawater-flooded pontoons for ballast — not a pressure vessel, higher payload, lower cost</li>
+          <li>Gravity-based de-ballast and small-capacity ferryboat-style trim system</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ===================== THE MODEL (problem + solution) ===================== -->
+    <section class="section" id="model">
+      <div class="container">
+        <p class="section-eyebrow">The Model</p>
+        <h2 class="section-title">Deepwater value is won or lost between host selection and first production.</h2>
+        <p class="lead">
+          Every deepwater development runs the same gauntlet before a single barrel is sold. The stretch from
+          <strong>FID to First Production</strong> is where operators bleed money — and where a standard,
+          pre-engineered host changes the economics.
+        </p>
+
+        <div class="lifecycle" aria-label="Deepwater development life cycle">
+          <ol class="lifecycle-track">
+            <li>Acquire</li>
+            <li>Explore</li>
+            <li>Appraise</li>
+            <li class="hot">Select</li>
+            <li class="hot">Define / FEED</li>
+            <li class="hot">FID</li>
+            <li class="hot">Execute</li>
+            <li class="hot">First Production</li>
+            <li>Operate</li>
+            <li>Abandon</li>
+          </ol>
+          <p class="lifecycle-note"><span class="dot"></span> The highlighted phases are the "kill zone" — where the MPSS compresses the timeline.</p>
+        </div>
+
+        <div class="split">
+          <div class="split-col">
+            <h3 class="split-head conventional">The conventional path</h3>
+            <ul class="flow flow-cold">
+              <li>A new host engineered around every field</li>
+              <li>Long, custom FEED &amp; risk-reduction cycle</li>
+              <li>Heavy long-lead procurement</li>
+              <li>Bespoke, engineering-intensive fabrication</li>
+              <li>Billions committed at FID before host risk is settled</li>
+              <li>Revenue delayed by host delivery</li>
+            </ul>
+          </div>
+          <div class="split-arrow" aria-hidden="true">→</div>
+          <div class="split-col">
+            <h3 class="split-head mpss">The MPSS path</h3>
+            <ul class="flow flow-hot">
+              <li>A validated standard host — classed and known</li>
+              <li>Known hull, known motions, known fabrication</li>
+              <li>The host becomes leaseable inventory before FID</li>
+              <li>Repeatable, predictable build</li>
+              <li>Lease structure reduces upfront capital exposure</li>
+              <li>Faster availability accelerates first oil</li>
+            </ul>
+          </div>
+        </div>
+
+        <blockquote class="pull-quote">
+          The conventional model designs a new host around every field. The MPSS reverses it — standard host
+          first, field-specific topsides second. That is the difference between a product and a project.
+        </blockquote>
+
+        <h3 class="subhead">Mapped to the drivers operators use to select a host</h3>
+        <div class="table-wrap">
+          <table class="matrix">
+            <thead>
+              <tr><th>Host selection driver</th><th>The MPSS answer</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>FID to first-production cycle time</td><td>Standard hull, faster fabrication, lease inventory available before FID</td></tr>
+              <tr><td>Predictable delivery</td><td>Repeatable design instead of a one-off custom semi</td></tr>
+              <tr><td>Standardization</td><td>The same hull, adapted by topside package</td></tr>
+              <tr><td>Capital efficiency</td><td>Lower hull cost, lower labor per tonne, faster revenue</td></tr>
+              <tr><td>Contracting flexibility</td><td>Lease, bareboat, JV, or sale options</td></tr>
+              <tr><td>Host payload &amp; deck</td><td>15,000&nbsp;t payload on a large, stable, open deck</td></tr>
+              <tr><td>Number of subsea tiebacks</td><td>Low-motion host strengthens the SCR / cable / riser support case</td></tr>
+              <tr><td>Onboard storage</td><td>Up to 2&nbsp;M&nbsp;bbl in the SWIS configuration — FPSO capability</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== HERITAGE ===================== -->
+    <section class="section section-alt" id="heritage">
+      <div class="container">
+        <p class="section-eyebrow">Heritage &amp; Validation</p>
+        <h2 class="section-title">Four decades of engineering, independently endorsed.</h2>
+        <p class="lead">
+          The MPSS was first proposed in 1980 by Craig Lang while working on the Conoco Hutton TLP. Since then
+          its principles have been analyzed, tank-tested, classed and published — and the engineers behind it
+          have contributed to some of the world's largest deepwater platforms.
+        </p>
+
+        <div class="cards cards-2">
+          <article class="card card-lg">
+            <h3>Independent endorsement</h3>
+            <ul class="ticks">
+              <li>Classification review by Lloyd's Register, ABS &amp; DNV</li>
+              <li>Design evaluated and endorsed by Prof. Douglas Faulkner, University of Glasgow</li>
+              <li>Peer-reviewed: "Design Evaluation of a Multi-Purpose Semisubmersible" (Faulkner, Incecik &amp; Lang)</li>
+              <li>Tank-tested at 1:100 scale; studied at Glasgow &amp; Newcastle universities</li>
+            </ul>
+          </article>
+          <article class="card card-lg">
+            <h3>Proven design heritage</h3>
+            <p>Seaways engineers have served as consultant design engineers on landmark deepwater
+              developments — and the MPSS configuration's principles are reflected across the industry.</p>
+            <ul class="logos">
+              <li>BP Thunder Horse<span>Gulf of Mexico · 300,000 bbl/day</span></li>
+              <li>Shell Na Kika<span>Gulf of Mexico</span></li>
+              <li>Petrobras P51 · P52 · P55 · P56<span>Campos &amp; Santos Basins, Brazil</span></li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== LEASING ===================== -->
+    <section class="section" id="leasing">
+      <div class="container">
+        <p class="section-eyebrow">The Business</p>
+        <h2 class="section-title">Leaseable offshore infrastructure — not a one-off build.</h2>
+        <p class="lead">
+          For deepwater, the host hull is effectively long-lead equipment. The MPSS converts it from a custom
+          project item into available leased infrastructure. A premium lease rate can be paid for by
+          accelerated revenue alone — if first oil is pulled forward even by months.
+        </p>
+
+        <div class="cards cards-2">
+          <article class="card card-lg">
+            <h3>Flexible commercial structures</h3>
+            <ul class="ticks">
+              <li>Time-charter &amp; bareboat lease</li>
+              <li>Joint venture &amp; risk-share</li>
+              <li>Lease-to-own and outright sale</li>
+              <li>Lease-after-lease redeployment</li>
+            </ul>
+          </article>
+          <article class="card card-lg">
+            <h3>Second-life &amp; residual value</h3>
+            <p>The MPSS keeps accepting work after first production — added tiebacks, extra modules, brownfield
+              debottlenecking, power, compression, CCS, hydrogen, or float-off / float-on redeployment to a new
+              field. That optionality supports high residual value.</p>
+          </article>
+        </div>
+
+        <div class="value-strip">
+          <p class="value-strip-title">A premium rate, justified by more than CAPEX:</p>
+          <ul class="value-list">
+            <li>Earlier first production</li>
+            <li>Reduced FEED uncertainty</li>
+            <li>Reduced fabrication risk</li>
+            <li>Reduced riser / cable fatigue</li>
+            <li>Easier topside expansion</li>
+            <li>Field-life extension</li>
+            <li>Redeployable asset value</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== CONTACT ===================== -->
+    <section class="section section-cta" id="contact">
+      <div class="container contact-inner">
+        <h2 class="section-title light">Let's talk about your field.</h2>
+        <p class="lead light">
+          Most operators aren't ready to buy a hull on the first conversation — but everyone understands the
+          pain of Select and Define. We help you shorten both with a validated standard host that can be
+          modeled, classed, leased and adapted to your field before FID.
+        </p>
+
+        <div class="contact-actions">
+          <a class="btn btn-primary" href="mailto:info@seaways-mpss.com?subject=MPSS%20enquiry">Email us</a>
+          <a class="btn btn-ghost light" href="#top">Back to top</a>
+        </div>
+
+        <ul class="contact-details">
+          <li><span class="c-label">Email</span><a href="mailto:info@seaways-mpss.com">info@seaways-mpss.com</a></li>
+          <li><span class="c-label">Web</span><a href="https://seaways-mpss.com/">seaways-mpss.com</a></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <!-- ===================== FOOTER ===================== -->
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#13273d"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>Seaways<span class="brand-accent"> MPSS</span></span>
+      </div>
+      <p class="footer-tag">LANG's MPSS — Simple · Safe · Swift · Size · Saves.</p>
+      <p class="footer-copy">© <span id="year"></span> Seaways MPSS. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -225,13 +225,13 @@
         <p class="section-eyebrow">Hull Comparison</p>
         <h2 class="section-title">Same job. A fundamentally different hull.</h2>
         <p class="lead">
-          Today's deepwater production semis are built on twin, ship-form pontoons with braced columns. The
-          MPSS replaces that with a continuous ring pontoon and uniform box construction at a deep single
-          draft — fewer parts, more deck, and lower motion.
+          Most deepwater floating production units (FPUs) are built on twin, ship-form pontoons with braced
+          columns. The MPSS replaces that with a continuous ring pontoon and uniform box construction at a
+          deep single draft — fewer parts, more deck, and lower motion.
         </p>
 
         <div class="hulls">
-          <!-- Conventional production semi: twin-pontoon -->
+          <!-- Semi-submersible FPU: twin-pontoon -->
           <figure class="hull-card">
             <div class="hull-art">
               <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of a twin-pontoon column-stabilized semi-submersible">
@@ -268,12 +268,12 @@
               </svg>
             </div>
             <figcaption>
-              <h3>Conventional production semi</h3>
-              <p class="hull-type">Twin-pontoon, column-stabilized deepwater semi</p>
+              <h3>Semi-submersible FPU</h3>
+              <p class="hull-type">Twin-pontoon, column-stabilized floating production unit</p>
             </figcaption>
           </figure>
 
-          <!-- Deepwater PDQ semi: twin-pontoon -->
+          <!-- Deepwater PDQ FPU: twin-pontoon -->
           <figure class="hull-card">
             <div class="hull-art">
               <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of a twin-pontoon semi-submersible production, drilling and quarters unit">
@@ -312,7 +312,7 @@
               </svg>
             </div>
             <figcaption>
-              <h3>Deepwater PDQ semi</h3>
+              <h3>Deepwater PDQ FPU</h3>
               <p class="hull-type">Twin-pontoon production · drilling · quarters unit</p>
             </figcaption>
           </figure>
@@ -364,7 +364,7 @@
         <div class="table-wrap">
           <table class="matrix">
             <thead>
-              <tr><th>Hull attribute</th><th>Conventional twin-pontoon semi</th><th>LANG's MPSS</th></tr>
+              <tr><th>Hull attribute</th><th>Conventional twin-pontoon FPU</th><th>LANG's MPSS</th></tr>
             </thead>
             <tbody>
               <tr><td>Pontoon form</td><td>Twin ship-form pontoons</td><td>Continuous ring pontoon</td></tr>

--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
         </p>
 
         <div class="hulls">
-          <!-- Shell Appomattox: twin-pontoon -->
+          <!-- Conventional production semi: twin-pontoon -->
           <figure class="hull-card">
             <div class="hull-art">
               <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of a twin-pontoon column-stabilized semi-submersible">
@@ -268,12 +268,12 @@
               </svg>
             </div>
             <figcaption>
-              <h3>Shell Appomattox</h3>
-              <p class="hull-type">Twin-pontoon, column-stabilized production semi · Gulf of Mexico</p>
+              <h3>Conventional production semi</h3>
+              <p class="hull-type">Twin-pontoon, column-stabilized deepwater semi</p>
             </figcaption>
           </figure>
 
-          <!-- BP Thunder Horse: twin-pontoon PDQ -->
+          <!-- Deepwater PDQ semi: twin-pontoon -->
           <figure class="hull-card">
             <div class="hull-art">
               <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of a twin-pontoon semi-submersible production, drilling and quarters unit">
@@ -312,8 +312,8 @@
               </svg>
             </div>
             <figcaption>
-              <h3>BP Thunder Horse</h3>
-              <p class="hull-type">Twin-pontoon semi-submersible PDQ · Gulf of Mexico</p>
+              <h3>Deepwater PDQ semi</h3>
+              <p class="hull-type">Twin-pontoon production · drilling · quarters unit</p>
             </figcaption>
           </figure>
 

--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
           <li><a href="#about">The MPSS</a></li>
           <li><a href="#five-s">The Five S</a></li>
           <li><a href="#specs">Specs</a></li>
+          <li><a href="#comparison">Comparison</a></li>
           <li><a href="#model">The Model</a></li>
-          <li><a href="#heritage">Heritage</a></li>
           <li><a href="#contact" class="nav-cta">Contact</a></li>
         </ul>
       </nav>
@@ -219,6 +219,167 @@
       </div>
     </section>
 
+    <!-- ===================== HULL COMPARISON ===================== -->
+    <section class="section section-alt" id="comparison">
+      <div class="container">
+        <p class="section-eyebrow">Hull Comparison</p>
+        <h2 class="section-title">Same job. A fundamentally different hull.</h2>
+        <p class="lead">
+          Today's deepwater production semis are built on twin, ship-form pontoons with braced columns. The
+          MPSS replaces that with a continuous ring pontoon and uniform box construction at a deep single
+          draft — fewer parts, more deck, and lower motion.
+        </p>
+
+        <div class="hulls">
+          <!-- Shell Appomattox: twin-pontoon -->
+          <figure class="hull-card">
+            <div class="hull-art">
+              <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of a twin-pontoon column-stabilized semi-submersible">
+                <rect x="0" y="140" width="320" height="70" fill="#0a2236"/>
+                <line x1="0" y1="140" x2="320" y2="140" stroke="#2ea3d9" stroke-opacity="0.4" stroke-width="2"/>
+                <path d="M0 148 Q40 142 80 148 T160 148 T240 148 T320 148" fill="none" stroke="#2ea3d9" stroke-opacity="0.18" stroke-width="2"/>
+                <!-- twin pontoons -->
+                <rect x="40" y="178" width="96" height="20" rx="5" fill="#0b3049"/>
+                <rect x="184" y="178" width="96" height="20" rx="5" fill="#0b3049"/>
+                <!-- bracing -->
+                <g stroke="#7f96ac" stroke-width="3">
+                  <line x1="70" y1="120" x2="108" y2="172"/><line x1="108" y1="120" x2="70" y2="172"/>
+                  <line x1="212" y1="120" x2="250" y2="172"/><line x1="250" y1="120" x2="212" y2="172"/>
+                  <line x1="136" y1="188" x2="184" y2="188"/>
+                </g>
+                <!-- columns -->
+                <rect x="52" y="108" width="18" height="70" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="108" y="108" width="18" height="70" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="194" y="108" width="18" height="70" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="250" y="108" width="18" height="70" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <!-- deck -->
+                <rect x="34" y="86" width="252" height="22" rx="3" fill="#e2e9f1"/>
+                <rect x="34" y="82" width="252" height="6" rx="3" fill="#9fb4c8"/>
+                <!-- topsides -->
+                <rect x="52" y="60" width="60" height="22" rx="2" fill="#cddae7"/>
+                <rect x="132" y="52" width="46" height="30" rx="2" fill="#dbe6f1"/>
+                <path d="M214 82 L228 40 L242 82 Z" fill="none" stroke="#aebfd1" stroke-width="3"/>
+                <!-- plan inset: twin -->
+                <g transform="translate(250,12)">
+                  <rect x="0" y="0" width="58" height="34" rx="4" fill="#ffffff" fill-opacity="0.07" stroke="#2ea3d9" stroke-opacity="0.35"/>
+                  <rect x="12" y="7" width="8" height="20" rx="2" fill="#2ea3d9" fill-opacity="0.75"/>
+                  <rect x="38" y="7" width="8" height="20" rx="2" fill="#2ea3d9" fill-opacity="0.75"/>
+                </g>
+              </svg>
+            </div>
+            <figcaption>
+              <h3>Shell Appomattox</h3>
+              <p class="hull-type">Twin-pontoon, column-stabilized production semi · Gulf of Mexico</p>
+            </figcaption>
+          </figure>
+
+          <!-- BP Thunder Horse: twin-pontoon PDQ -->
+          <figure class="hull-card">
+            <div class="hull-art">
+              <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of a twin-pontoon semi-submersible production, drilling and quarters unit">
+                <rect x="0" y="140" width="320" height="70" fill="#0a2236"/>
+                <line x1="0" y1="140" x2="320" y2="140" stroke="#2ea3d9" stroke-opacity="0.4" stroke-width="2"/>
+                <path d="M0 148 Q40 142 80 148 T160 148 T240 148 T320 148" fill="none" stroke="#2ea3d9" stroke-opacity="0.18" stroke-width="2"/>
+                <!-- twin pontoons -->
+                <rect x="34" y="176" width="102" height="22" rx="5" fill="#0b3049"/>
+                <rect x="184" y="176" width="102" height="22" rx="5" fill="#0b3049"/>
+                <!-- bracing -->
+                <g stroke="#7f96ac" stroke-width="3">
+                  <line x1="66" y1="118" x2="106" y2="170"/><line x1="106" y1="118" x2="66" y2="170"/>
+                  <line x1="214" y1="118" x2="254" y2="170"/><line x1="254" y1="118" x2="214" y2="170"/>
+                  <line x1="136" y1="187" x2="184" y2="187"/>
+                  <line x1="120" y1="112" x2="200" y2="170"/><line x1="200" y1="112" x2="120" y2="170"/>
+                </g>
+                <!-- columns (heavier) -->
+                <rect x="48" y="104" width="20" height="74" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="104" y="104" width="20" height="74" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="196" y="104" width="20" height="74" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="252" y="104" width="20" height="74" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <!-- deck (large PDQ) -->
+                <rect x="30" y="80" width="260" height="24" rx="3" fill="#e2e9f1"/>
+                <rect x="30" y="76" width="260" height="6" rx="3" fill="#9fb4c8"/>
+                <!-- topsides: quarters + derrick + modules -->
+                <rect x="44" y="52" width="52" height="28" rx="2" fill="#dbe6f1"/>
+                <rect x="112" y="58" width="44" height="22" rx="2" fill="#cddae7"/>
+                <path d="M186 76 L202 34 L218 76 Z" fill="none" stroke="#aebfd1" stroke-width="3"/>
+                <rect x="236" y="56" width="34" height="24" rx="2" fill="#cddae7"/>
+                <!-- plan inset: twin -->
+                <g transform="translate(250,12)">
+                  <rect x="0" y="0" width="58" height="34" rx="4" fill="#ffffff" fill-opacity="0.07" stroke="#2ea3d9" stroke-opacity="0.35"/>
+                  <rect x="12" y="7" width="8" height="20" rx="2" fill="#2ea3d9" fill-opacity="0.75"/>
+                  <rect x="38" y="7" width="8" height="20" rx="2" fill="#2ea3d9" fill-opacity="0.75"/>
+                </g>
+              </svg>
+            </div>
+            <figcaption>
+              <h3>BP Thunder Horse</h3>
+              <p class="hull-type">Twin-pontoon semi-submersible PDQ · Gulf of Mexico</p>
+            </figcaption>
+          </figure>
+
+          <!-- MPSS: ring pontoon box -->
+          <figure class="hull-card hull-card-mpss">
+            <div class="hull-art">
+              <svg viewBox="0 0 320 210" role="img" aria-label="Schematic of the MPSS ring-pontoon box semi-submersible">
+                <rect x="0" y="140" width="320" height="70" fill="#0a2236"/>
+                <line x1="0" y1="140" x2="320" y2="140" stroke="#2ea3d9" stroke-opacity="0.4" stroke-width="2"/>
+                <path d="M0 148 Q40 142 80 148 T160 148 T240 148 T320 148" fill="none" stroke="#2ea3d9" stroke-opacity="0.18" stroke-width="2"/>
+                <!-- continuous ring pontoon (deep) -->
+                <rect x="40" y="180" width="240" height="24" rx="7" fill="#0b3049"/>
+                <!-- safety belt of ballast at waterline -->
+                <rect x="40" y="136" width="240" height="9" rx="2" fill="#2ea3d9" fill-opacity="0.2"/>
+                <!-- box columns (no bracing) -->
+                <rect x="56" y="104" width="22" height="76" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="116" y="104" width="22" height="76" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="182" y="104" width="22" height="76" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <rect x="242" y="104" width="22" height="76" fill="#c3d2e2" stroke="#9fb4c8"/>
+                <!-- buoyant box deck (taller) -->
+                <rect x="32" y="78" width="256" height="26" rx="3" fill="#eef3f9"/>
+                <rect x="32" y="74" width="256" height="6" rx="3" fill="#9fb4c8"/>
+                <!-- skid-on topsides + derrick + flare -->
+                <rect x="48" y="50" width="58" height="28" rx="2" fill="#dbe6f1"/>
+                <rect x="126" y="42" width="52" height="36" rx="2" fill="#cddae7"/>
+                <path d="M196 74 L212 34 L228 74 Z" fill="none" stroke="#aebfd1" stroke-width="3"/>
+                <rect x="244" y="48" width="14" height="30" fill="#b9c9d9"/>
+                <circle cx="251" cy="42" r="6" fill="#ff8a3d" opacity="0.85"/>
+                <!-- plan inset: ring -->
+                <g transform="translate(250,12)">
+                  <rect x="0" y="0" width="58" height="34" rx="4" fill="#ffffff" fill-opacity="0.07" stroke="#2ea3d9" stroke-opacity="0.35"/>
+                  <rect x="11" y="7" width="36" height="20" rx="3" fill="none" stroke="#2ea3d9" stroke-width="5" stroke-opacity="0.85"/>
+                </g>
+              </svg>
+            </div>
+            <figcaption>
+              <h3>LANG's MPSS</h3>
+              <p class="hull-type">Continuous ring pontoon · box construction · deep single draft</p>
+            </figcaption>
+          </figure>
+        </div>
+
+        <p class="hull-note">
+          Schematic hull illustrations for comparison — not to scale. The plan-view insets contrast the
+          twin ship-form pontoons of conventional semis with the MPSS continuous ring pontoon.
+        </p>
+
+        <div class="table-wrap">
+          <table class="matrix">
+            <thead>
+              <tr><th>Hull attribute</th><th>Conventional twin-pontoon semi</th><th>LANG's MPSS</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Pontoon form</td><td>Twin ship-form pontoons</td><td>Continuous ring pontoon</td></tr>
+              <tr><td>Columns</td><td>Braced, often tubular</td><td>Unbraced box columns</td></tr>
+              <tr><td>Construction</td><td>Bespoke, engineering-intensive</td><td>Standardized mild-steel box, panel-line built</td></tr>
+              <tr><td>Operating draft</td><td>Changes to a survival draft in heavy seas</td><td>Single deep operating draft — constant production</td></tr>
+              <tr><td>Motion</td><td>Reacts to surface waves</td><td>Low heave from deep-draft damping</td></tr>
+              <tr><td>Deck</td><td>Truss-supported, often crowded</td><td>Large open box deck, high payload</td></tr>
+              <tr><td>Onboard storage</td><td>Typically none — needs an FPSO or tanker</td><td>Up to 2&nbsp;M&nbsp;bbl in the SWIS configuration</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
     <!-- ===================== THE MODEL (problem + solution) ===================== -->
     <section class="section" id="model">
       <div class="container">
@@ -304,9 +465,9 @@
         <p class="section-eyebrow">Heritage &amp; Validation</p>
         <h2 class="section-title">Four decades of engineering, independently endorsed.</h2>
         <p class="lead">
-          The MPSS was first proposed in 1980 by Craig Lang while working on the Conoco Hutton TLP. Since then
-          its principles have been analyzed, tank-tested, classed and published — and the engineers behind it
-          have contributed to some of the world's largest deepwater platforms.
+          The MPSS was first proposed in 1980 by Craig Lang, drawing on deepwater tension-leg-platform
+          mooring engineering. Since then its principles have been analyzed, tank-tested, classed and
+          published in the peer-reviewed literature.
         </p>
 
         <div class="cards cards-2">
@@ -316,17 +477,17 @@
               <li>Classification review by Lloyd's Register, ABS &amp; DNV</li>
               <li>Design evaluated and endorsed by Prof. Douglas Faulkner, University of Glasgow</li>
               <li>Peer-reviewed: "Design Evaluation of a Multi-Purpose Semisubmersible" (Faulkner, Incecik &amp; Lang)</li>
-              <li>Tank-tested at 1:100 scale; studied at Glasgow &amp; Newcastle universities</li>
+              <li>Lloyd's certification covering primary structure, stability, mooring &amp; ballast systems</li>
             </ul>
           </article>
           <article class="card card-lg">
-            <h3>Proven design heritage</h3>
-            <p>Seaways engineers have served as consultant design engineers on landmark deepwater
-              developments — and the MPSS configuration's principles are reflected across the industry.</p>
-            <ul class="logos">
-              <li>BP Thunder Horse<span>Gulf of Mexico · 300,000 bbl/day</span></li>
-              <li>Shell Na Kika<span>Gulf of Mexico</span></li>
-              <li>Petrobras P51 · P52 · P55 · P56<span>Campos &amp; Santos Basins, Brazil</span></li>
+            <h3>Tested &amp; analyzed</h3>
+            <p>Every dimension of the design has been examined independently:</p>
+            <ul class="ticks">
+              <li>Hydrodynamic behavior &amp; motions</li>
+              <li>Structural strength &amp; fatigue life</li>
+              <li>Intact &amp; damaged stability and moorings</li>
+              <li>1:100-scale tank testing; doctoral research at Glasgow &amp; Newcastle</li>
             </ul>
           </article>
         </div>
@@ -388,12 +549,12 @@
         </p>
 
         <div class="contact-actions">
-          <a class="btn btn-primary" href="mailto:info@seaways-mpss.com?subject=MPSS%20enquiry">Email us</a>
+          <a class="btn btn-primary" href="mailto:stewart.lang@seaways-mpss.com?subject=MPSS%20enquiry">Email us</a>
           <a class="btn btn-ghost light" href="#top">Back to top</a>
         </div>
 
         <ul class="contact-details">
-          <li><span class="c-label">Email</span><a href="mailto:info@seaways-mpss.com">info@seaways-mpss.com</a></li>
+          <li><span class="c-label">Email</span><a href="mailto:stewart.lang@seaways-mpss.com">stewart.lang@seaways-mpss.com</a></li>
           <li><span class="c-label">Web</span><a href="https://seaways-mpss.com/">seaways-mpss.com</a></li>
         </ul>
       </div>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,29 @@
+/* Seaways MPSS — small progressive-enhancement script */
+(function () {
+  "use strict";
+
+  // Mobile nav toggle
+  var toggle = document.querySelector(".nav-toggle");
+  var menu = document.getElementById("nav-menu");
+
+  if (toggle && menu) {
+    toggle.addEventListener("click", function () {
+      var open = menu.classList.toggle("open");
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+
+    // Close the menu after tapping a link (mobile)
+    menu.addEventListener("click", function (e) {
+      if (e.target.tagName === "A") {
+        menu.classList.remove("open");
+        toggle.setAttribute("aria-expanded", "false");
+      }
+    });
+  }
+
+  // Current year in footer
+  var yearEl = document.getElementById("year");
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -469,6 +469,41 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
 .logos li:last-child { border-bottom: 0; }
 .logos li span { font-weight: 500; font-size: .86rem; color: var(--slate-light); }
 
+/* ===================== HULL COMPARISON ===================== */
+.hulls {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+  margin-bottom: 18px;
+}
+.hull-card {
+  margin: 0;
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.hull-card-mpss {
+  border: 2px solid var(--accent);
+  box-shadow: 0 8px 30px rgba(46, 163, 217, .22);
+}
+.hull-art {
+  background: linear-gradient(180deg, #163a5a 0%, #0f2f4b 100%);
+  line-height: 0;
+}
+.hull-art svg { width: 100%; height: auto; display: block; }
+.hull-card figcaption { padding: 18px 20px 20px; }
+.hull-card figcaption h3 { font-size: 1.16rem; color: var(--navy-900); margin-bottom: 6px; }
+.hull-card-mpss figcaption h3 { color: var(--accent-deep); }
+.hull-type { margin: 0; font-size: .92rem; color: var(--slate-light); }
+.hull-note {
+  font-size: .88rem;
+  color: var(--slate-light);
+  margin: 0 0 34px;
+  font-style: italic;
+}
+
 /* ===================== TABLES ===================== */
 .table-wrap { overflow-x: auto; border-radius: var(--radius); box-shadow: var(--shadow-sm); }
 .matrix {
@@ -570,6 +605,7 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
   .split-arrow { transform: rotate(90deg); }
   .hero-content { padding-bottom: 130px; }
   .specs-grid { grid-template-columns: 1fr 1fr; }
+  .hulls { grid-template-columns: 1fr; max-width: 460px; margin-left: auto; margin-right: auto; }
   .five-s { grid-template-columns: repeat(4, 1fr); }
   .five-s .s-card:nth-child(1),
   .five-s .s-card:nth-child(2) { grid-column: span 2; }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,621 @@
+/* =========================================================
+   Seaways MPSS — stylesheet
+   Palette: deep navy / ocean blue / steel
+   ========================================================= */
+
+:root {
+  --navy-900: #0a1a2f;
+  --navy-800: #0d2138;
+  --navy-700: #13273d;
+  --navy-600: #1b3b5b;
+  --ink: #14212e;
+  --slate: #4a5a6b;
+  --slate-light: #64748b;
+  --line: #e2e8f0;
+  --bg: #ffffff;
+  --bg-alt: #f5f8fb;
+  --bg-tint: #eef4fa;
+  --accent: #2ea3d9;
+  --accent-deep: #1c7fb0;
+  --accent-glow: #57c4f0;
+  --flare: #ff8a3d;
+  --white: #ffffff;
+
+  --maxw: 1120px;
+  --radius: 14px;
+  --radius-sm: 9px;
+  --shadow-sm: 0 1px 2px rgba(10, 26, 47, .06), 0 4px 14px rgba(10, 26, 47, .06);
+  --shadow-md: 0 8px 30px rgba(10, 26, 47, .12);
+
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  color: var(--ink);
+  background: var(--bg);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.container {
+  width: 100%;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+a { color: var(--accent-deep); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
+
+/* ===================== HEADER ===================== */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, .88);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--line);
+}
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 68px;
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  font-size: 1.18rem;
+  letter-spacing: -0.02em;
+  color: var(--navy-900);
+}
+.brand:hover { text-decoration: none; }
+.brand-accent { color: var(--accent-deep); }
+.brand-mark { flex: none; }
+
+.site-nav { display: flex; align-items: center; }
+.nav-menu {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.nav-menu a {
+  display: inline-block;
+  padding: 8px 14px;
+  border-radius: 8px;
+  color: var(--slate);
+  font-size: .95rem;
+  font-weight: 500;
+}
+.nav-menu a:hover { color: var(--navy-900); background: var(--bg-tint); text-decoration: none; }
+.nav-cta {
+  color: var(--white) !important;
+  background: var(--navy-900);
+}
+.nav-cta:hover { background: var(--navy-700) !important; }
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 44px;
+  height: 44px;
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  cursor: pointer;
+}
+.nav-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  margin: 0 auto;
+  background: var(--navy-900);
+  transition: transform .25s, opacity .25s;
+}
+
+/* ===================== HERO ===================== */
+.hero {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(180deg, #0a1a2f 0%, #0e2846 55%, #103356 100%);
+  color: #eaf2fb;
+  padding: 72px 0 0;
+}
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: flex;
+  align-items: flex-end;
+  pointer-events: none;
+}
+.hero-platform { width: 100%; height: auto; opacity: .95; }
+.hero-content {
+  position: relative;
+  z-index: 1;
+  padding-bottom: 190px;
+  max-width: 820px;
+}
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  font-size: .78rem;
+  font-weight: 600;
+  color: var(--accent-glow);
+  margin: 0 0 18px;
+}
+.hero h1 {
+  font-size: clamp(2.1rem, 5.2vw, 3.55rem);
+  font-weight: 800;
+  color: #fff;
+  margin-bottom: 22px;
+}
+.grad {
+  background: linear-gradient(100deg, var(--accent-glow), #9ad9f6);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.hero-sub {
+  font-size: clamp(1.02rem, 1.8vw, 1.22rem);
+  color: #c4d6e8;
+  max-width: 660px;
+  margin: 0 0 30px;
+}
+.hero-sub strong { color: #fff; font-weight: 600; }
+
+.hero-actions { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 44px; }
+
+.btn {
+  display: inline-block;
+  padding: 13px 26px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform .12s ease, background .2s ease, box-shadow .2s ease;
+}
+.btn:hover { text-decoration: none; transform: translateY(-1px); }
+.btn-primary {
+  background: var(--accent);
+  color: #06263a;
+  box-shadow: 0 6px 20px rgba(46, 163, 217, .35);
+}
+.btn-primary:hover { background: var(--accent-glow); }
+.btn-ghost {
+  background: rgba(255, 255, 255, .08);
+  color: #eaf2fb;
+  border: 1px solid rgba(255, 255, 255, .28);
+}
+.btn-ghost:hover { background: rgba(255, 255, 255, .16); }
+.btn-ghost.light { color: #eaf2fb; }
+
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 40px;
+  list-style: none;
+  margin: 0;
+  padding: 22px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, .14);
+}
+.hero-stats li { display: flex; flex-direction: column; }
+.stat-num { font-weight: 700; color: #fff; font-size: 1.05rem; letter-spacing: -0.01em; }
+.stat-label { font-size: .84rem; color: #9fb6cd; }
+
+/* ===================== SECTIONS ===================== */
+.section { padding: 88px 0; }
+.section-alt { background: var(--bg-alt); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.section-dark { background: linear-gradient(180deg, #0d2138, #0a1a2f); }
+.section-cta { background: linear-gradient(160deg, #103356, #0a1a2f); }
+
+.section-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  font-size: .76rem;
+  font-weight: 700;
+  color: var(--accent-deep);
+  margin: 0 0 14px;
+}
+.section-eyebrow.light { color: var(--accent-glow); }
+.section-title {
+  font-size: clamp(1.6rem, 3.4vw, 2.35rem);
+  font-weight: 800;
+  color: var(--navy-900);
+  max-width: 820px;
+  margin-bottom: 18px;
+}
+.section-title.light { color: #fff; }
+.lead {
+  font-size: 1.12rem;
+  color: var(--slate);
+  max-width: 760px;
+  margin: 0 0 40px;
+}
+.lead.light { color: #bcd0e4; }
+.lead strong { color: var(--navy-900); }
+.lead.light strong { color: #fff; }
+
+/* ===================== LIFECYCLE ===================== */
+.lifecycle { margin: 0 0 48px; }
+.lifecycle-track {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 14px;
+  counter-reset: step;
+}
+.lifecycle-track li {
+  position: relative;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--white);
+  border: 1px solid var(--line);
+  font-weight: 600;
+  font-size: .92rem;
+  color: var(--slate);
+}
+.lifecycle-track li.hot {
+  background: linear-gradient(120deg, #0e2846, #14507a);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+.lifecycle-note { font-size: .9rem; color: var(--slate-light); display: flex; align-items: center; gap: 8px; }
+.dot { width: 12px; height: 12px; border-radius: 3px; background: linear-gradient(120deg, #0e2846, #14507a); display: inline-block; }
+
+/* ===================== CARDS ===================== */
+.cards { display: grid; gap: 22px; }
+.cards-3 { grid-template-columns: repeat(3, 1fr); }
+.cards-2 { grid-template-columns: repeat(2, 1fr); }
+.card {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px;
+  box-shadow: var(--shadow-sm);
+}
+.card h3 { font-size: 1.14rem; color: var(--navy-900); margin-bottom: 10px; }
+.card p { margin: 0; color: var(--slate); }
+.card-lg { padding: 30px; }
+.card-lg h3 { font-size: 1.28rem; margin-bottom: 14px; }
+
+.ticks { list-style: none; margin: 0; padding: 0; }
+.ticks li { position: relative; padding: 8px 0 8px 30px; color: var(--ink); border-bottom: 1px solid var(--line); }
+.ticks li:last-child { border-bottom: 0; }
+.ticks li::before {
+  content: "";
+  position: absolute; left: 2px; top: 14px;
+  width: 8px; height: 14px;
+  border: solid var(--accent-deep);
+  border-width: 0 2.5px 2.5px 0;
+  transform: rotate(45deg);
+}
+
+/* ===================== SPLIT (conventional vs mpss) ===================== */
+.split {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 24px;
+  align-items: stretch;
+  margin-bottom: 40px;
+}
+.split-col {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px;
+  box-shadow: var(--shadow-sm);
+}
+.split-head {
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  padding-bottom: 14px;
+  margin-bottom: 8px;
+  border-bottom: 2px solid var(--line);
+}
+.split-head.conventional { color: var(--slate-light); }
+.split-head.mpss { color: var(--accent-deep); }
+.split-arrow {
+  align-self: center;
+  font-size: 2rem;
+  color: var(--accent);
+  font-weight: 700;
+}
+.flow { list-style: none; margin: 0; padding: 0; }
+.flow li { padding: 10px 0; border-bottom: 1px dashed var(--line); font-size: .96rem; }
+.flow li:last-child { border-bottom: 0; }
+.flow-cold li { color: var(--slate-light); }
+.flow-hot li { color: var(--ink); font-weight: 500; }
+
+.pull-quote {
+  margin: 0;
+  padding: 30px 34px;
+  background: linear-gradient(120deg, #0e2846, #14507a);
+  color: #eaf4fb;
+  border-radius: var(--radius);
+  font-size: 1.28rem;
+  font-weight: 600;
+  line-height: 1.4;
+  box-shadow: var(--shadow-md);
+}
+
+.subhead {
+  font-size: 1.28rem;
+  font-weight: 700;
+  color: var(--navy-900);
+  margin: 48px 0 20px;
+}
+
+/* ===================== FIVE S ===================== */
+.five-s {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 22px;
+}
+.s-card {
+  grid-column: span 3;
+  position: relative;
+  overflow: hidden;
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 28px 28px 26px;
+  box-shadow: var(--shadow-sm);
+}
+.five-s .s-card:nth-child(1),
+.five-s .s-card:nth-child(2) { grid-column: span 3; }
+.five-s .s-card:nth-child(3),
+.five-s .s-card:nth-child(4),
+.five-s .s-card:nth-child(5) { grid-column: span 2; }
+.s-letter {
+  position: absolute;
+  top: -18px;
+  right: 6px;
+  font-size: 7rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--bg-tint);
+  z-index: 0;
+  user-select: none;
+}
+.s-card h3 {
+  position: relative;
+  z-index: 1;
+  font-size: 1.35rem;
+  color: var(--accent-deep);
+  margin-bottom: 12px;
+}
+.s-card p { position: relative; z-index: 1; margin: 0; color: var(--slate); }
+
+/* ===================== SPECS ===================== */
+.specs-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+  background: rgba(255, 255, 255, .1);
+  border: 1px solid rgba(255, 255, 255, .1);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 30px;
+}
+.spec {
+  background: #0c2137;
+  padding: 30px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.spec-num {
+  font-size: clamp(2rem, 4vw, 2.9rem);
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.spec-num small { font-size: .42em; font-weight: 700; color: var(--accent-glow); margin-left: 4px; }
+.spec-label { font-size: .95rem; color: #a7c0d8; }
+
+.spec-notes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 28px;
+}
+.spec-notes li {
+  position: relative;
+  padding-left: 26px;
+  color: #b9cde0;
+  font-size: .98rem;
+}
+.spec-notes li::before {
+  content: "";
+  position: absolute; left: 2px; top: 9px;
+  width: 8px; height: 8px; border-radius: 2px;
+  background: var(--accent);
+}
+
+/* ===================== HERITAGE LOGOS ===================== */
+.logos { list-style: none; margin: 18px 0 0; padding: 16px 0 0; border-top: 1px solid var(--line); }
+.logos li {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 0;
+  font-weight: 700;
+  color: var(--navy-900);
+  border-bottom: 1px solid var(--line);
+}
+.logos li:last-child { border-bottom: 0; }
+.logos li span { font-weight: 500; font-size: .86rem; color: var(--slate-light); }
+
+/* ===================== TABLES ===================== */
+.table-wrap { overflow-x: auto; border-radius: var(--radius); box-shadow: var(--shadow-sm); }
+.matrix {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--white);
+  min-width: 560px;
+}
+.matrix th, .matrix td {
+  text-align: left;
+  padding: 15px 20px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+}
+.matrix thead th {
+  background: var(--navy-900);
+  color: #fff;
+  font-size: .82rem;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+.matrix tbody td:first-child { font-weight: 600; color: var(--navy-900); width: 34%; }
+.matrix tbody td { color: var(--slate); }
+.matrix tbody tr:nth-child(even) { background: var(--bg-alt); }
+.matrix tbody tr:last-child td { border-bottom: 0; }
+
+.matrix-dark { background: rgba(255, 255, 255, .03); }
+.matrix-dark thead th { background: #06131f; }
+.matrix-dark th, .matrix-dark td { border-bottom-color: rgba(255, 255, 255, .1); }
+.matrix-dark tbody td:first-child { color: #fff; }
+.matrix-dark tbody td { color: #b9cde0; }
+.matrix-dark tbody tr:nth-child(even) { background: rgba(255, 255, 255, .03); }
+
+/* ===================== VALUE STRIP ===================== */
+.value-strip {
+  margin-top: 34px;
+  padding: 28px 30px;
+  background: var(--bg-tint);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+.value-strip-title { margin: 0 0 16px; font-weight: 700; color: var(--navy-900); }
+.value-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.value-list li {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-weight: 600;
+  font-size: .92rem;
+  color: var(--navy-800);
+}
+
+/* ===================== CONTACT ===================== */
+.contact-inner { max-width: 760px; }
+.contact-actions { display: flex; flex-wrap: wrap; gap: 14px; margin: 6px 0 34px; }
+.contact-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 48px;
+  list-style: none;
+  margin: 0;
+  padding: 24px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, .16);
+}
+.contact-details li { display: flex; flex-direction: column; gap: 3px; }
+.c-label { font-size: .76rem; text-transform: uppercase; letter-spacing: .12em; color: #8fabc6; }
+.contact-details a { color: #eaf4fb; font-weight: 600; font-size: 1.05rem; }
+
+/* ===================== FOOTER ===================== */
+.site-footer {
+  background: var(--navy-900);
+  color: #a9c0d6;
+  padding: 40px 0;
+}
+.footer-inner { display: flex; flex-direction: column; gap: 8px; align-items: flex-start; }
+.footer-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+.footer-tag { margin: 0; color: #8fabc6; }
+.footer-copy { margin: 0; font-size: .88rem; color: #6f8ba6; }
+
+/* ===================== RESPONSIVE ===================== */
+@media (max-width: 900px) {
+  .cards-3 { grid-template-columns: 1fr 1fr; }
+  .split { grid-template-columns: 1fr; }
+  .split-arrow { transform: rotate(90deg); }
+  .hero-content { padding-bottom: 130px; }
+  .specs-grid { grid-template-columns: 1fr 1fr; }
+  .five-s { grid-template-columns: repeat(4, 1fr); }
+  .five-s .s-card:nth-child(1),
+  .five-s .s-card:nth-child(2) { grid-column: span 2; }
+  .five-s .s-card:nth-child(3),
+  .five-s .s-card:nth-child(4) { grid-column: span 2; }
+  .five-s .s-card:nth-child(5) { grid-column: span 4; }
+}
+
+@media (max-width: 720px) {
+  .nav-toggle { display: flex; }
+  .nav-menu {
+    position: absolute;
+    top: 68px;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding: 14px 18px 20px;
+    background: var(--white);
+    border-bottom: 1px solid var(--line);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-140%);
+    transition: transform .28s ease;
+    visibility: hidden;
+  }
+  .nav-menu.open { transform: translateY(0); visibility: visible; }
+  .nav-menu a { padding: 12px 14px; }
+  .nav-cta { text-align: center; }
+
+  .cards-3, .cards-2 { grid-template-columns: 1fr; }
+  .specs-grid { grid-template-columns: 1fr; }
+  .spec-notes { grid-template-columns: 1fr; }
+  .five-s { grid-template-columns: 1fr; }
+  .five-s .s-card:nth-child(n) { grid-column: span 1; }
+  .section { padding: 64px 0; }
+  .hero { padding-top: 48px; }
+  .hero-content { padding-bottom: 90px; }
+  .pull-quote { font-size: 1.1rem; padding: 24px; }
+}
+
+@media (max-width: 420px) {
+  .hero-stats { gap: 14px 22px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .btn:hover { transform: none; }
+}


### PR DESCRIPTION
## Summary

A responsive, single-page static marketing site for **Seaways MPSS** — LANG's Multi-Purpose Semi-Submersible — structured around the five-S design philosophy: **Simple · Safe · Swift · Size · Saves.** The site positions the MPSS as a validated, standardized deepwater production host and pre-positioned, leaseable offshore infrastructure.

## What's included

- **`index.html`** — full page: hero, "The MPSS" overview, the Five S, specifications, hull comparison, the commercial model, heritage & validation, leasing, and contact.
- **`styles.css`** — navy / ocean-blue / steel palette; fully responsive (desktop → mobile).
- **`main.js`** — mobile nav toggle and footer year; the site works without JS.

## Content highlights

- **The Five S** and by-the-numbers specs drawn from Seaways Engineering source material: 15,000 t payload, 8,100 m² deck, up to 2M bbl SWIS storage, 37.5 m survival wave, ~14-month hull delivery, LR/ABS/DNV classification.
- **Hull comparison** — hand-built schematic side-elevation illustrations (with waterline and plan-view insets) contrasting conventional twin-pontoon **FPUs** against the MPSS continuous ring pontoon, plus an attribute comparison table. No operator or third-party platform names are used.
- **The commercial model** — the FID→First-Production "kill zone," a product-vs-project framing, the host-selection driver matrix, and leasing structures.
- **Heritage & validation** limited to independent endorsement (classification societies, academic review, peer-reviewed paper) and testing — no operator/customer claims.

## Notes

- All graphics are hand-built inline SVG / HTML+CSS — no third-party or copyrighted chart/photo images.
- Contact email is `stewart.lang@seaways-mpss.com`.
- Deployable to any static host (GitHub Pages, Netlify, Cloudflare Pages, etc.) for the `seaways-mpss.com` domain.
- Rendering verified on desktop and mobile viewports with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mmzu5WVSCohv4fEX294kuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mmzu5WVSCohv4fEX294kuh)_