### PR TITLE
Add interactive day-rate leasing model

### DIFF
--- a/day-rates.html
+++ b/day-rates.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Day-Rate Model — Seaways MPSS</title>
+  <meta name="description" content="An editable day-rate model for the Seaways MPSS. Change lease day rates and swap potential tenants — oil production, drilling, offshore wind, data center, CCS, hydrogen — in and out to compare the economics." />
+  <meta name="theme-color" content="#0a1a2f" />
+  <meta name="robots" content="noindex" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a1a2f'/%3E%3Cpath d='M4 20h24M8 20v-6h16v6M13 14V9h6v5' stroke='%232ea3d9' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
+</head>
+<body>
+  <!-- ===================== HEADER ===================== -->
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a href="index.html#top" class="brand" aria-label="Seaways MPSS home">
+        <svg class="brand-mark" viewBox="0 0 32 32" width="34" height="34" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#0a1a2f"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="brand-text">Seaways<span class="brand-accent"> MPSS</span></span>
+      </a>
+
+      <nav class="site-nav" aria-label="Primary">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul id="nav-menu" class="nav-menu">
+          <li><a href="index.html#about">The MPSS</a></li>
+          <li><a href="index.html#specs">Specs</a></li>
+          <li><a href="index.html#model">The Model</a></li>
+          <li><a href="day-rates.html" aria-current="page">Day Rates</a></li>
+          <li><a href="index.html#contact" class="nav-cta">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- ===================== INTRO ===================== -->
+    <section class="section calc-intro">
+      <div class="container">
+        <p class="section-eyebrow">Leasing Economics</p>
+        <h1 class="section-title">Day-rate model.</h1>
+        <p class="lead">
+          A working, editable model of the MPSS as leaseable infrastructure. Change any
+          <strong>day rate</strong>, swap potential tenants in and out, and the revenue, net and payback
+          recompute instantly. Every number below is editable — the defaults are illustrative placeholders,
+          not quotes. Your changes are saved in this browser, and you can export the whole thing to a
+          spreadsheet (CSV) for Excel or Google Sheets.
+        </p>
+      </div>
+    </section>
+
+    <!-- ===================== CALCULATOR ===================== -->
+    <section class="section section-alt calc-section" style="padding-top:0;">
+      <div class="container">
+
+        <!-- Toolbar -->
+        <div class="calc-toolbar">
+          <div class="calc-add">
+            <label for="preset-select" class="calc-add-label">Add a tenant</label>
+            <div class="calc-add-row">
+              <select id="preset-select" class="calc-select" aria-label="Choose a tenant to add"></select>
+              <button type="button" id="add-preset" class="btn btn-primary btn-sm">Add tenant</button>
+              <button type="button" id="add-blank" class="btn btn-ghost btn-sm">Blank row</button>
+            </div>
+          </div>
+          <div class="calc-tools">
+            <button type="button" id="export-csv" class="btn btn-ghost btn-sm">Export CSV</button>
+            <button type="button" id="reset-all" class="btn btn-ghost btn-sm calc-danger">Reset to defaults</button>
+          </div>
+        </div>
+
+        <!-- Global assumptions -->
+        <div class="calc-assumptions">
+          <div class="assume-field">
+            <label for="capex">Host build / lease-in cost (CAPEX)</label>
+            <div class="input-money">
+              <span class="prefix">$</span>
+              <input type="text" inputmode="numeric" id="capex" class="calc-num" />
+            </div>
+            <span class="assume-hint">Used for payback &amp; return-on-asset.</span>
+          </div>
+          <div class="assume-field">
+            <label for="days-year">On-hire days per year (max)</label>
+            <input type="text" inputmode="numeric" id="days-year" class="calc-num" />
+            <span class="assume-hint">365 for a full year; utilisation is applied per tenant.</span>
+          </div>
+        </div>
+
+        <!-- The spreadsheet -->
+        <div class="table-wrap calc-table-wrap">
+          <table class="calc-table" id="rate-table">
+            <thead>
+              <tr>
+                <th class="col-on"><abbr title="Include this tenant in the totals">On</abbr></th>
+                <th class="col-name">Tenant / use case</th>
+                <th class="col-in">Day rate<br><small>$/day</small></th>
+                <th class="col-in">Term<br><small>years</small></th>
+                <th class="col-in">Utilisation<br><small>%</small></th>
+                <th class="col-in">Operating cost<br><small>$/day</small></th>
+                <th class="col-calc">Revenue / yr</th>
+                <th class="col-calc">Net / yr</th>
+                <th class="col-calc">Net over term</th>
+                <th class="col-calc">Payback</th>
+                <th class="col-x" aria-label="Remove"></th>
+              </tr>
+            </thead>
+            <tbody id="rate-body"><!-- rows injected by JS --></tbody>
+            <tfoot>
+              <tr class="calc-total-row">
+                <td></td>
+                <td class="calc-total-label">Active tenants (blended)</td>
+                <td class="num" id="t-dayrate">—</td>
+                <td></td>
+                <td class="num" id="t-util">—</td>
+                <td></td>
+                <td class="num calc-calc" id="t-rev">—</td>
+                <td class="num calc-calc" id="t-net">—</td>
+                <td class="num calc-calc" id="t-termnet">—</td>
+                <td class="num calc-calc" id="t-payback">—</td>
+                <td></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+        <p class="calc-foot-note" id="empty-note" hidden>
+          No tenants yet — add one from the list above to start modelling.
+        </p>
+
+        <!-- Comparison bars -->
+        <div class="calc-compare">
+          <h3 class="subhead">Net revenue per year — compare tenants</h3>
+          <div id="compare-bars" class="compare-bars"><!-- bars injected by JS --></div>
+        </div>
+
+        <p class="hull-note calc-disclaimer">
+          Illustrative model for discussion only. Day rates, terms, utilisation, operating costs and CAPEX
+          are placeholder defaults you can edit — they are not offers, quotes or guarantees. Net revenue is
+          shown before financing, tax and mobilisation. Payback is CAPEX ÷ net revenue per year.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <!-- ===================== FOOTER ===================== -->
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#13273d"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>Seaways<span class="brand-accent"> MPSS</span></span>
+      </div>
+      <p class="footer-tag">LANG's MPSS — Simple · Safe · Swift · Size · Saves.</p>
+      <p class="footer-copy">© <span id="year"></span> Seaways MPSS. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="main.js"></script>
+  <script src="day-rates.js"></script>
+</body>
+</html>

--- a/day-rates.js
+++ b/day-rates.js
@@ -1,0 +1,427 @@
+/* =========================================================
+   Seaways MPSS — Day-rate model
+   A small, dependency-free spreadsheet-style calculator.
+   Edit day rates, swap tenants in/out, export to CSV.
+   ========================================================= */
+(function () {
+  "use strict";
+
+  var STORE_KEY = "mpss-day-rate-model-v1";
+
+  /* ---- Preset tenant library (illustrative defaults, all editable) ---- */
+  var PRESETS = [
+    { name: "Oil production host (FPSO)", dayRate: 350000, termYears: 8,  utilPct: 92, opexDay: 70000 },
+    { name: "Drilling support",           dayRate: 300000, termYears: 3,  utilPct: 85, opexDay: 65000 },
+    { name: "Offshore wind turbine install", dayRate: 180000, termYears: 2, utilPct: 80, opexDay: 55000 },
+    { name: "Offshore data center",       dayRate: 220000, termYears: 10, utilPct: 95, opexDay: 60000 },
+    { name: "Power generation",           dayRate: 160000, termYears: 10, utilPct: 90, opexDay: 45000 },
+    { name: "CCS / carbon storage",       dayRate: 200000, termYears: 12, utilPct: 90, opexDay: 50000 },
+    { name: "Green hydrogen",             dayRate: 210000, termYears: 10, utilPct: 88, opexDay: 55000 },
+    { name: "Accommodation / flotel",     dayRate: 120000, termYears: 2,  utilPct: 80, opexDay: 40000 }
+  ];
+
+  /* ---- Default model shown on first visit ---- */
+  function defaultState() {
+    return {
+      capex: 600000000,
+      daysYear: 365,
+      rows: [
+        makeRow(PRESETS[0]),
+        makeRow(PRESETS[3]),
+        makeRow(PRESETS[2])
+      ]
+    };
+  }
+
+  var _id = 0;
+  function makeRow(preset) {
+    return {
+      id: "r" + (++_id) + "_" + Date.now().toString(36),
+      name: preset.name,
+      dayRate: preset.dayRate,
+      termYears: preset.termYears,
+      utilPct: preset.utilPct,
+      opexDay: preset.opexDay,
+      enabled: true
+    };
+  }
+
+  /* ---- State load / save ---- */
+  var state = load() || defaultState();
+
+  function load() {
+    try {
+      var raw = localStorage.getItem(STORE_KEY);
+      if (!raw) return null;
+      var s = JSON.parse(raw);
+      if (!s || !Array.isArray(s.rows)) return null;
+      return s;
+    } catch (e) { return null; }
+  }
+  function save() {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(state)); } catch (e) {}
+  }
+
+  /* ---- Number helpers ---- */
+  function toNum(v) {
+    if (typeof v === "number") return isFinite(v) ? v : 0;
+    var n = parseFloat(String(v).replace(/[^0-9.\-]/g, ""));
+    return isFinite(n) ? n : 0;
+  }
+  function fmtMoney(n) {
+    n = Math.round(toNum(n));
+    return "$" + n.toLocaleString("en-US");
+  }
+  function fmtMoneyShort(n) {
+    n = toNum(n);
+    var abs = Math.abs(n);
+    if (abs >= 1e9) return "$" + (n / 1e9).toFixed(2).replace(/\.00$/, "") + "B";
+    if (abs >= 1e6) return "$" + (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+    if (abs >= 1e3) return "$" + Math.round(n / 1e3) + "k";
+    return "$" + Math.round(n);
+  }
+  function fmtInt(n) { return Math.round(toNum(n)).toLocaleString("en-US"); }
+
+  /* ---- Per-row economics ---- */
+  function calcRow(row) {
+    var onHireDays = toNum(state.daysYear) * (toNum(row.utilPct) / 100);
+    var revYear = toNum(row.dayRate) * onHireDays;
+    var opexYear = toNum(row.opexDay) * onHireDays;
+    var netYear = revYear - opexYear;
+    var netTerm = netYear * toNum(row.termYears);
+    var payback = netYear > 0 ? toNum(state.capex) / netYear : Infinity;
+    return {
+      onHireDays: onHireDays,
+      revYear: revYear,
+      netYear: netYear,
+      netTerm: netTerm,
+      payback: payback
+    };
+  }
+
+  /* ---- DOM refs ---- */
+  var body = document.getElementById("rate-body");
+  var presetSelect = document.getElementById("preset-select");
+  var capexInput = document.getElementById("capex");
+  var daysYearInput = document.getElementById("days-year");
+  var emptyNote = document.getElementById("empty-note");
+  var compareWrap = document.getElementById("compare-bars");
+
+  /* ---- Populate preset dropdown ---- */
+  PRESETS.forEach(function (p, i) {
+    var opt = document.createElement("option");
+    opt.value = String(i);
+    opt.textContent = p.name;
+    presetSelect.appendChild(opt);
+  });
+
+  /* ---- Build a spreadsheet cell input ---- */
+  function cell(row, field, opts) {
+    opts = opts || {};
+    var td = document.createElement("td");
+    td.className = "col-in" + (opts.money ? " col-money" : "");
+    var wrap = td;
+    if (opts.money) {
+      wrap = document.createElement("div");
+      wrap.className = "input-money";
+      var pre = document.createElement("span");
+      pre.className = "prefix";
+      pre.textContent = "$";
+      wrap.appendChild(pre);
+      td.appendChild(wrap);
+    }
+    var input = document.createElement("input");
+    input.type = "text";
+    input.setAttribute("inputmode", opts.decimal ? "decimal" : "numeric");
+    input.className = "calc-num";
+    input.value = displayVal(row[field], opts);
+    input.setAttribute("aria-label", opts.label || field);
+    input.addEventListener("focus", function () { input.select(); });
+    input.addEventListener("input", function () {
+      row[field] = toNum(input.value);
+      recompute();
+      save();
+    });
+    input.addEventListener("blur", function () {
+      input.value = displayVal(row[field], opts);
+    });
+    wrap.appendChild(input);
+    return td;
+  }
+  function displayVal(v, opts) {
+    if (opts && opts.money) return toNum(v).toLocaleString("en-US");
+    return String(toNum(v));
+  }
+
+  /* ---- Render a single tenant row ---- */
+  function renderRow(row) {
+    var tr = document.createElement("tr");
+    tr.dataset.id = row.id;
+    if (!row.enabled) tr.className = "row-off";
+
+    // On/off toggle
+    var tdOn = document.createElement("td");
+    tdOn.className = "col-on";
+    var chk = document.createElement("input");
+    chk.type = "checkbox";
+    chk.checked = !!row.enabled;
+    chk.setAttribute("aria-label", "Include " + row.name + " in totals");
+    chk.addEventListener("change", function () {
+      row.enabled = chk.checked;
+      render();
+      save();
+    });
+    tdOn.appendChild(chk);
+    tr.appendChild(tdOn);
+
+    // Name (editable)
+    var tdName = document.createElement("td");
+    tdName.className = "col-name";
+    var nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.className = "calc-name-input";
+    nameInput.value = row.name;
+    nameInput.setAttribute("aria-label", "Tenant name");
+    nameInput.addEventListener("input", function () {
+      row.name = nameInput.value;
+      recompute();
+      save();
+    });
+    tdName.appendChild(nameInput);
+    tr.appendChild(tdName);
+
+    // Editable inputs
+    tr.appendChild(cell(row, "dayRate", { money: true, label: "Day rate" }));
+    tr.appendChild(cell(row, "termYears", { decimal: true, label: "Term in years" }));
+    tr.appendChild(cell(row, "utilPct", { decimal: true, label: "Utilisation percent" }));
+    tr.appendChild(cell(row, "opexDay", { money: true, label: "Operating cost per day" }));
+
+    // Computed columns
+    var c = calcRow(row);
+    tr.appendChild(calcCell(fmtMoney(c.revYear)));
+    tr.appendChild(calcCell(fmtMoney(c.netYear), c.netYear < 0 ? "neg" : ""));
+    tr.appendChild(calcCell(fmtMoney(c.netTerm), c.netTerm < 0 ? "neg" : ""));
+    tr.appendChild(calcCell(c.payback === Infinity ? "—" : c.payback.toFixed(1) + " yr"));
+
+    // Remove
+    var tdX = document.createElement("td");
+    tdX.className = "col-x";
+    var rm = document.createElement("button");
+    rm.type = "button";
+    rm.className = "row-remove";
+    rm.innerHTML = "&times;";
+    rm.setAttribute("aria-label", "Remove " + row.name);
+    rm.title = "Remove tenant";
+    rm.addEventListener("click", function () {
+      state.rows = state.rows.filter(function (r) { return r.id !== row.id; });
+      render();
+      save();
+    });
+    tdX.appendChild(rm);
+    tr.appendChild(tdX);
+
+    return tr;
+  }
+  function calcCell(text, cls) {
+    var td = document.createElement("td");
+    td.className = "num calc-calc" + (cls ? " " + cls : "");
+    td.textContent = text;
+    return td;
+  }
+
+  /* ---- Recompute only the computed cells + totals (no full re-render) ---- */
+  function recompute() {
+    Array.prototype.forEach.call(body.querySelectorAll("tr"), function (tr) {
+      var row = state.rows.find(function (r) { return r.id === tr.dataset.id; });
+      if (!row) return;
+      var c = calcRow(row);
+      var calcCells = tr.querySelectorAll(".calc-calc");
+      // order: rev, net, termnet, payback
+      if (calcCells[0]) calcCells[0].textContent = fmtMoney(c.revYear);
+      if (calcCells[1]) { calcCells[1].textContent = fmtMoney(c.netYear); calcCells[1].classList.toggle("neg", c.netYear < 0); }
+      if (calcCells[2]) { calcCells[2].textContent = fmtMoney(c.netTerm); calcCells[2].classList.toggle("neg", c.netTerm < 0); }
+      if (calcCells[3]) calcCells[3].textContent = c.payback === Infinity ? "—" : c.payback.toFixed(1) + " yr";
+    });
+    updateTotals();
+    renderCompare();
+  }
+
+  /* ---- Totals across ENABLED tenants (blended average book) ---- */
+  function updateTotals() {
+    var active = state.rows.filter(function (r) { return r.enabled; });
+    var sumRev = 0, sumNet = 0, sumTermNet = 0, sumRate = 0, sumUtil = 0;
+    active.forEach(function (r) {
+      var c = calcRow(r);
+      sumRev += c.revYear;
+      sumNet += c.netYear;
+      sumTermNet += c.netTerm;
+      sumRate += toNum(r.dayRate);
+      sumUtil += toNum(r.utilPct);
+    });
+    var n = active.length;
+    var payback = sumNet > 0 ? toNum(state.capex) / sumNet : Infinity;
+
+    document.getElementById("t-dayrate").textContent = n ? "avg " + fmtMoney(sumRate / n) : "—";
+    document.getElementById("t-util").textContent = n ? "avg " + (sumUtil / n).toFixed(0) + "%" : "—";
+    document.getElementById("t-rev").textContent = n ? fmtMoney(sumRev) : "—";
+    document.getElementById("t-net").textContent = n ? fmtMoney(sumNet) : "—";
+    document.getElementById("t-termnet").textContent = n ? fmtMoney(sumTermNet) : "—";
+    document.getElementById("t-payback").textContent = n && payback !== Infinity ? payback.toFixed(1) + " yr" : "—";
+  }
+
+  /* ---- Comparison bars (net revenue per year) ---- */
+  function renderCompare() {
+    compareWrap.innerHTML = "";
+    if (!state.rows.length) {
+      compareWrap.innerHTML = '<p class="hull-note" style="margin:0;">Add tenants to compare.</p>';
+      return;
+    }
+    var max = 0;
+    state.rows.forEach(function (r) {
+      var net = calcRow(r).netYear;
+      if (net > max) max = net;
+    });
+    if (max <= 0) max = 1;
+
+    state.rows.forEach(function (r) {
+      var c = calcRow(r);
+      var pct = Math.max(0, (c.netYear / max) * 100);
+
+      var item = document.createElement("div");
+      item.className = "compare-item" + (r.enabled ? "" : " compare-off");
+
+      var label = document.createElement("div");
+      label.className = "compare-label";
+      label.textContent = r.name || "Unnamed";
+      item.appendChild(label);
+
+      var track = document.createElement("div");
+      track.className = "compare-track";
+      var bar = document.createElement("div");
+      bar.className = "compare-bar";
+      bar.style.width = pct.toFixed(1) + "%";
+      track.appendChild(bar);
+      item.appendChild(track);
+
+      var val = document.createElement("div");
+      val.className = "compare-val";
+      val.textContent = fmtMoneyShort(c.netYear) + "/yr";
+      item.appendChild(val);
+
+      compareWrap.appendChild(item);
+    });
+  }
+
+  /* ---- Full render ---- */
+  function render() {
+    body.innerHTML = "";
+    state.rows.forEach(function (row) {
+      body.appendChild(renderRow(row));
+    });
+    emptyNote.hidden = state.rows.length > 0;
+    capexInput.value = toNum(state.capex).toLocaleString("en-US");
+    daysYearInput.value = String(toNum(state.daysYear));
+    updateTotals();
+    renderCompare();
+  }
+
+  /* ---- Toolbar wiring ---- */
+  document.getElementById("add-preset").addEventListener("click", function () {
+    var i = parseInt(presetSelect.value, 10);
+    if (isNaN(i) || !PRESETS[i]) return;
+    state.rows.push(makeRow(PRESETS[i]));
+    render();
+    save();
+  });
+  document.getElementById("add-blank").addEventListener("click", function () {
+    state.rows.push(makeRow({ name: "New tenant", dayRate: 0, termYears: 5, utilPct: 90, opexDay: 0 }));
+    render();
+    save();
+  });
+  document.getElementById("reset-all").addEventListener("click", function () {
+    if (!window.confirm("Reset the whole model back to the default tenants and rates? Your edits will be lost.")) return;
+    state = defaultState();
+    render();
+    save();
+  });
+  capexInput.addEventListener("input", function () {
+    state.capex = toNum(capexInput.value);
+    recompute();
+    save();
+  });
+  capexInput.addEventListener("blur", function () {
+    capexInput.value = toNum(state.capex).toLocaleString("en-US");
+  });
+  daysYearInput.addEventListener("input", function () {
+    state.daysYear = toNum(daysYearInput.value);
+    recompute();
+    save();
+  });
+
+  /* ---- CSV export (opens in Excel / Google Sheets) ---- */
+  document.getElementById("export-csv").addEventListener("click", exportCsv);
+  function csvCell(v) {
+    var s = String(v == null ? "" : v);
+    if (/[",\n]/.test(s)) s = '"' + s.replace(/"/g, '""') + '"';
+    return s;
+  }
+  function exportCsv() {
+    var lines = [];
+    lines.push(["Seaways MPSS — Day-rate model"].map(csvCell).join(","));
+    lines.push([].join(","));
+    lines.push(["CAPEX", toNum(state.capex)].map(csvCell).join(","));
+    lines.push(["On-hire days/year (max)", toNum(state.daysYear)].map(csvCell).join(","));
+    lines.push([].join(","));
+    lines.push([
+      "Included", "Tenant / use case", "Day rate ($/day)", "Term (years)",
+      "Utilisation (%)", "Operating cost ($/day)", "On-hire days/yr",
+      "Revenue/yr ($)", "Net/yr ($)", "Net over term ($)", "Payback (yr)"
+    ].map(csvCell).join(","));
+
+    state.rows.forEach(function (r) {
+      var c = calcRow(r);
+      lines.push([
+        r.enabled ? "Yes" : "No",
+        r.name,
+        toNum(r.dayRate),
+        toNum(r.termYears),
+        toNum(r.utilPct),
+        toNum(r.opexDay),
+        Math.round(c.onHireDays),
+        Math.round(c.revYear),
+        Math.round(c.netYear),
+        Math.round(c.netTerm),
+        c.payback === Infinity ? "" : c.payback.toFixed(1)
+      ].map(csvCell).join(","));
+    });
+
+    // Totals row (active tenants)
+    var active = state.rows.filter(function (r) { return r.enabled; });
+    var sumRev = 0, sumNet = 0, sumTermNet = 0;
+    active.forEach(function (r) {
+      var c = calcRow(r);
+      sumRev += c.revYear; sumNet += c.netYear; sumTermNet += c.netTerm;
+    });
+    var payback = sumNet > 0 ? toNum(state.capex) / sumNet : "";
+    lines.push([].join(","));
+    lines.push([
+      "", "TOTAL (active tenants)", "", "", "", "", "",
+      Math.round(sumRev), Math.round(sumNet), Math.round(sumTermNet),
+      payback === "" ? "" : payback.toFixed(1)
+    ].map(csvCell).join(","));
+
+    var csv = lines.join("\r\n");
+    var blob = new Blob(["﻿" + csv], { type: "text/csv;charset=utf-8;" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    a.download = "mpss-day-rate-model.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+  }
+
+  /* ---- Go ---- */
+  render();
+})();

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
           <li><a href="#specs">Specs</a></li>
           <li><a href="#comparison">Comparison</a></li>
           <li><a href="#model">The Model</a></li>
+          <li><a href="day-rates.html">Day Rates</a></li>
           <li><a href="#contact" class="nav-cta">Contact</a></li>
         </ul>
       </nav>

--- a/styles.css
+++ b/styles.css
@@ -655,3 +655,216 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
   html { scroll-behavior: auto; }
   .btn:hover { transform: none; }
 }
+
+/* =========================================================
+   Day-rate model (day-rates.html)
+   ========================================================= */
+.calc-intro { padding-bottom: 28px; }
+.calc-intro h1.section-title { font-size: clamp(2rem, 5vw, 3rem); }
+
+.btn-sm { padding: 9px 16px; font-size: .92rem; }
+
+/* Toolbar */
+.calc-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+.calc-add-label,
+.assume-field label {
+  display: block;
+  font-size: .8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--slate);
+  margin-bottom: 7px;
+}
+.calc-add-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.calc-tools { display: flex; flex-wrap: wrap; gap: 10px; }
+.calc-select {
+  font: inherit;
+  font-size: .95rem;
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  color: var(--ink);
+  min-width: 210px;
+}
+.calc-select:focus,
+.calc-num:focus,
+.calc-name-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(46, 163, 217, .18);
+}
+.calc-danger { color: #b4443a; }
+.calc-danger:hover { border-color: #b4443a; }
+
+/* Global assumptions */
+.calc-assumptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 26px;
+  padding: 20px 22px;
+  margin-bottom: 22px;
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+.assume-field { min-width: 220px; }
+.assume-hint { display: block; font-size: .78rem; color: var(--slate-light); margin-top: 5px; }
+
+/* Money input */
+.input-money { position: relative; display: inline-flex; align-items: center; width: 100%; }
+.input-money .prefix {
+  position: absolute;
+  left: 10px;
+  color: var(--slate-light);
+  font-size: .9rem;
+  pointer-events: none;
+}
+.input-money .calc-num { padding-left: 22px; min-width: 122px; }
+
+.calc-num {
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+  min-width: 78px;
+  padding: 9px 10px;
+  text-align: right;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  color: var(--ink);
+}
+#capex, #days-year { max-width: 220px; }
+
+/* The spreadsheet table */
+.calc-table-wrap { border-radius: var(--radius); }
+.calc-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--white);
+  font-size: .92rem;
+  min-width: 960px;
+}
+.calc-table thead th {
+  background: var(--navy-800);
+  color: #dbe7f2;
+  font-size: .74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .03em;
+  text-align: right;
+  padding: 12px 12px;
+  vertical-align: bottom;
+  border-bottom: 2px solid var(--navy-600);
+}
+.calc-table thead th small { font-weight: 500; opacity: .7; text-transform: none; letter-spacing: 0; }
+.calc-table thead th abbr { text-decoration: none; border: 0; cursor: help; }
+.calc-table th.col-on, .calc-table th.col-name { text-align: left; }
+.calc-table th.col-x { width: 34px; }
+
+.calc-table tbody td {
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+.calc-table tbody tr:nth-child(even) td { background: var(--bg-alt); }
+.calc-table tbody tr:hover td { background: var(--bg-tint); }
+.calc-table .col-on { text-align: center; width: 46px; }
+.calc-table .col-on input { width: 17px; height: 17px; accent-color: var(--accent-deep); cursor: pointer; }
+.calc-table .col-name { min-width: 210px; }
+.calc-table .col-in { width: 116px; }
+.calc-table .col-in.col-money { width: 146px; }
+
+.calc-name-input {
+  font: inherit;
+  font-weight: 600;
+  width: 100%;
+  min-width: 170px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink);
+}
+.calc-name-input:hover { border-color: var(--line); background: var(--white); }
+
+/* Computed cells */
+.calc-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.calc-table .calc-calc {
+  font-weight: 700;
+  color: var(--navy-700);
+  background: rgba(46, 163, 217, .05);
+}
+.calc-table .calc-calc.neg { color: #b4443a; }
+
+/* Rows toggled off */
+.calc-table tr.row-off td:not(.col-on):not(.col-x) { opacity: .42; }
+
+.row-remove {
+  border: 0;
+  background: transparent;
+  color: var(--slate-light);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+.row-remove:hover { color: #b4443a; background: rgba(180, 68, 58, .1); }
+
+/* Totals row */
+.calc-total-row td {
+  background: var(--navy-800) !important;
+  color: #eaf2fa;
+  font-weight: 700;
+  padding: 13px 12px;
+  border: 0;
+}
+.calc-total-row .calc-calc { color: var(--accent-glow); background: transparent; }
+.calc-total-label { text-align: left; letter-spacing: .01em; }
+
+.calc-foot-note { color: var(--slate); font-style: italic; margin-top: 14px; }
+
+/* Comparison bars */
+.calc-compare { margin-top: 40px; }
+.compare-bars { display: flex; flex-direction: column; gap: 12px; margin-top: 18px; }
+.compare-item {
+  display: grid;
+  grid-template-columns: 200px 1fr 108px;
+  align-items: center;
+  gap: 14px;
+}
+.compare-label { font-weight: 600; font-size: .92rem; color: var(--ink); }
+.compare-track {
+  height: 22px;
+  background: var(--bg-tint);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.compare-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-deep), var(--accent));
+  border-radius: 6px;
+  min-width: 2px;
+  transition: width .25s ease;
+}
+.compare-val { text-align: right; font-weight: 700; font-variant-numeric: tabular-nums; color: var(--navy-700); }
+.compare-off { opacity: .4; }
+.compare-off .compare-bar { background: var(--slate-light); }
+
+.calc-disclaimer { margin-top: 34px; }
+
+@media (max-width: 700px) {
+  .calc-toolbar { flex-direction: column; align-items: stretch; }
+  .compare-item { grid-template-columns: 120px 1fr 82px; gap: 10px; }
+  .compare-label { font-size: .82rem; }
+}


### PR DESCRIPTION
Adds day-rates.html — an editable, spreadsheet-style tool for modelling
the MPSS as leaseable infrastructure:

- Editable day rate, term, utilisation and operating cost per tenant
- A preset tenant library (oil/FPSO, drilling, offshore wind, data
  center, power, CCS, hydrogen, accommodation) you can add, remove or
  toggle in and out of the totals
- Live revenue / net / net-over-term / payback, plus blended totals and
  a per-tenant comparison chart
- Editable CAPEX and on-hire-days assumptions used for payback
- CSV export (Excel / Google Sheets) and localStorage persistence

Links the new page from the primary nav.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CbmMKyED53yNbZozHskAVE