### PR TITLE
Add lease-vs-build market-opportunity section to the day-rate page

### DIFF
--- a/day-rates.html
+++ b/day-rates.html
@@ -144,6 +144,128 @@
         </p>
       </div>
     </section>
+
+    <!-- ===================== LEASE VS BUILD / OPPORTUNITY ===================== -->
+    <section class="section" id="lease-vs-build">
+      <div class="container">
+        <p class="section-eyebrow">Lease vs. Build</p>
+        <h2 class="section-title">Why a ready host sells — even when the majors build their own.</h2>
+        <p class="lead">
+          The model above prices the asset. This is the case for it. A standard host that already
+          exists — or has its design frozen, long-lead items ordered and a yard slot held — is not
+          competing with an operator's in-house host programme. It sells them the one thing that
+          programme can never be: <strong>fast</strong>. That is the whole trade.
+        </p>
+
+        <div class="split">
+          <div class="split-col">
+            <h3 class="split-head conventional">Build your own host</h3>
+            <ul class="flow flow-cold">
+              <li>A new host engineered around one field</li>
+              <li>3–4 years of custom design before steel is cut</li>
+              <li>A yard slot queued 2–4 years out in a tight market</li>
+              <li>First-of-a-kind cost and schedule risk on the buyer</li>
+              <li>Billions committed at FID before host risk is settled</li>
+              <li>Revenue delayed by host delivery</li>
+            </ul>
+          </div>
+          <div class="split-arrow" aria-hidden="true">→</div>
+          <div class="split-col">
+            <h3 class="split-head mpss">Lease a ready MPSS</h3>
+            <ul class="flow flow-hot">
+              <li>A validated, class-approved host — LR, ABS &amp; DNV</li>
+              <li>Design known, motions known, fabrication known</li>
+              <li>~14-month hull delivery from a held slot</li>
+              <li>First-of-a-kind risk already retired</li>
+              <li>Capex shifts to opex — a lease, not a balance-sheet build</li>
+              <li>First oil pulled forward by a year or more</li>
+            </ul>
+          </div>
+        </div>
+
+        <blockquote class="pull-quote">
+          "The majors already do this" cuts <em>for</em> the MPSS, not against it. Every bespoke host
+          is slow, first-of-a-kind and capital-locked for years. A ready host is the option they can
+          exercise the moment a discovery, an outgrown tieback or a redevelopment appears.
+        </blockquote>
+
+        <h3 class="subhead">The case, in four parts</h3>
+        <div class="cards cards-2">
+          <article class="card">
+            <h3>You're selling schedule</h3>
+            <p>
+              Deepwater value is won or lost between host selection and first production. Pulling first
+              oil forward a year or two on a field doing 60–100&nbsp;kbbl/d is worth hundreds of millions
+              in NPV. That delta is the price umbrella the lease sits under.
+            </p>
+          </article>
+          <article class="card">
+            <h3>The addressable set is the long tail</h3>
+            <p>
+              Not just the flagship greenfield. It's the pile of marginal discoveries, near-field
+              accumulations and outgrown subsea tiebacks that don't clear the hurdle rate against a
+              $1–3&nbsp;B bespoke host — but do against a leaseable one. Every major and NOC has a drawer
+              full of them. That is the "other fields in the portfolio."
+            </p>
+          </article>
+          <article class="card">
+            <h3>The leasing market already exists</h3>
+            <p>
+              FPSO leasing — Modec, SBM, Yinson, BW, Bumi Armada — is a multi-billion-dollar business
+              built on exactly this logic: shift the floater off the balance sheet. The MPSS ports that
+              model to the production host. It also tells you the earliest buyers are independents and
+              NOCs, not the majors — capital-constrained, with no in-house host engineering.
+            </p>
+          </article>
+          <article class="card">
+            <h3>A ready asset is a bidding war</h3>
+            <p>
+              When yards are full, steel and rates are high and two operators need a host in the same
+              window, the one who can't wait pays a premium. Replacement cost plus time-to-replicate is
+              scarcity value — the same dynamic that spikes rig and FPSO day-rates in every up-cycle.
+            </p>
+          </article>
+        </div>
+
+        <h3 class="subhead">Who leases, and why</h3>
+        <div class="table-wrap">
+          <table class="matrix">
+            <thead>
+              <tr><th>Buyer</th><th>Why a ready host wins</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Independent / mid-cap operator</td><td>No in-house host engineering; leasing shifts capex to opex and de-risks delivery</td></tr>
+              <tr><td>National oil company</td><td>Capital-constrained; a classed standard host removes first-of-a-kind and schedule risk</td></tr>
+              <tr><td>Major, marginal field</td><td>The accumulation doesn't clear the hurdle rate for a bespoke host, but does for a leased one</td></tr>
+              <tr><td>Major, redevelopment / tieback</td><td>A ring-pontoon host with 15,000&nbsp;t payload absorbs added tiebacks and brownfield modules</td></tr>
+              <tr><td>Any operator, tight market</td><td>A held yard slot beats a 2–4 year queue — availability is the auction</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3 class="subhead">What a sharp buyer will push on</h3>
+        <div class="cards cards-2">
+          <article class="card card-lg">
+            <h3>Financing steel on spec</h3>
+            <p>
+              The honest weak point isn't demand — it's committing to a hull without an anchor charter.
+              The answer is you don't build blind: freeze the design, hold the yard slot, order the
+              long-lead items. That alone promises a delivery date years inside any bespoke competitor's
+              — which is what triggers the bidding war — without carrying a finished hull looking for a home.
+            </p>
+          </article>
+          <article class="card card-lg">
+            <h3>Field fit</h3>
+            <p>
+              Metocean (the 37.5&nbsp;m survival wave), water depth, payload, storage and local-content
+              rules vary by field. A spec unit has to be "good enough" across a target basin, not perfect
+              for one field. Standardization is sized to a design envelope: pick the basin, then sell into
+              everything inside it — topsides adapt, the hull doesn't.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
   </main>
 
   <!-- ===================== FOOTER ===================== -->

--- a/day-rates.html
+++ b/day-rates.html
@@ -54,104 +54,13 @@
       </div>
     </section>
 
-    <!-- ===================== CALCULATOR ===================== -->
-    <section class="section section-alt calc-section" style="padding-top:0;">
-      <div class="container">
-
-        <!-- Toolbar -->
-        <div class="calc-toolbar">
-          <div class="calc-add">
-            <label for="preset-select" class="calc-add-label">Add a tenant</label>
-            <div class="calc-add-row">
-              <select id="preset-select" class="calc-select" aria-label="Choose a tenant to add"></select>
-              <button type="button" id="add-preset" class="btn btn-primary btn-sm">Add tenant</button>
-              <button type="button" id="add-blank" class="btn btn-ghost btn-sm">Blank row</button>
-            </div>
-          </div>
-          <div class="calc-tools">
-            <button type="button" id="export-csv" class="btn btn-ghost btn-sm">Export CSV</button>
-            <button type="button" id="reset-all" class="btn btn-ghost btn-sm calc-danger">Reset to defaults</button>
-          </div>
-        </div>
-
-        <!-- Global assumptions -->
-        <div class="calc-assumptions">
-          <div class="assume-field">
-            <label for="capex">Host build / lease-in cost (CAPEX)</label>
-            <div class="input-money">
-              <span class="prefix">$</span>
-              <input type="text" inputmode="numeric" id="capex" class="calc-num" />
-            </div>
-            <span class="assume-hint">Used for payback &amp; return-on-asset.</span>
-          </div>
-          <div class="assume-field">
-            <label for="days-year">On-hire days per year (max)</label>
-            <input type="text" inputmode="numeric" id="days-year" class="calc-num" />
-            <span class="assume-hint">365 for a full year; utilisation is applied per tenant.</span>
-          </div>
-        </div>
-
-        <!-- The spreadsheet -->
-        <div class="table-wrap calc-table-wrap">
-          <table class="calc-table" id="rate-table">
-            <thead>
-              <tr>
-                <th class="col-on"><abbr title="Include this tenant in the totals">On</abbr></th>
-                <th class="col-name">Tenant / use case</th>
-                <th class="col-in">Day rate<br><small>$/day</small></th>
-                <th class="col-in">Term<br><small>years</small></th>
-                <th class="col-in">Utilisation<br><small>%</small></th>
-                <th class="col-in">Operating cost<br><small>$/day</small></th>
-                <th class="col-calc">Revenue / yr</th>
-                <th class="col-calc">Net / yr</th>
-                <th class="col-calc">Net over term</th>
-                <th class="col-calc">Payback</th>
-                <th class="col-x" aria-label="Remove"></th>
-              </tr>
-            </thead>
-            <tbody id="rate-body"><!-- rows injected by JS --></tbody>
-            <tfoot>
-              <tr class="calc-total-row">
-                <td></td>
-                <td class="calc-total-label">Active tenants (blended)</td>
-                <td class="num" id="t-dayrate">—</td>
-                <td></td>
-                <td class="num" id="t-util">—</td>
-                <td></td>
-                <td class="num calc-calc" id="t-rev">—</td>
-                <td class="num calc-calc" id="t-net">—</td>
-                <td class="num calc-calc" id="t-termnet">—</td>
-                <td class="num calc-calc" id="t-payback">—</td>
-                <td></td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
-        <p class="calc-foot-note" id="empty-note" hidden>
-          No tenants yet — add one from the list above to start modelling.
-        </p>
-
-        <!-- Comparison bars -->
-        <div class="calc-compare">
-          <h3 class="subhead">Net revenue per year — compare tenants</h3>
-          <div id="compare-bars" class="compare-bars"><!-- bars injected by JS --></div>
-        </div>
-
-        <p class="hull-note calc-disclaimer">
-          Illustrative model for discussion only. Day rates, terms, utilisation, operating costs and CAPEX
-          are placeholder defaults you can edit — they are not offers, quotes or guarantees. Net revenue is
-          shown before financing, tax and mobilisation. Payback is CAPEX ÷ net revenue per year.
-        </p>
-      </div>
-    </section>
-
     <!-- ===================== LEASE VS BUILD / OPPORTUNITY ===================== -->
     <section class="section" id="lease-vs-build">
       <div class="container">
         <p class="section-eyebrow">Lease vs. Build</p>
         <h2 class="section-title">Why a ready host sells — even when the majors build their own.</h2>
         <p class="lead">
-          The model above prices the asset. This is the case for it. A standard host that already
+          The model below prices the asset. This is the case for it. A standard host that already
           exists — or has its design frozen, long-lead items ordered and a yard slot held — is not
           competing with an operator's in-house host programme. It sells them the one thing that
           programme can never be: <strong>fast</strong>. That is the whole trade.
@@ -266,6 +175,98 @@
         </div>
       </div>
     </section>
+
+    <!-- ===================== CALCULATOR ===================== -->
+    <section class="section section-alt calc-section" style="padding-top:0;">
+      <div class="container">
+
+        <!-- Toolbar -->
+        <div class="calc-toolbar">
+          <div class="calc-add">
+            <label for="preset-select" class="calc-add-label">Add a tenant</label>
+            <div class="calc-add-row">
+              <select id="preset-select" class="calc-select" aria-label="Choose a tenant to add"></select>
+              <button type="button" id="add-preset" class="btn btn-primary btn-sm">Add tenant</button>
+              <button type="button" id="add-blank" class="btn btn-ghost btn-sm">Blank row</button>
+            </div>
+          </div>
+          <div class="calc-tools">
+            <button type="button" id="export-csv" class="btn btn-ghost btn-sm">Export CSV</button>
+            <button type="button" id="reset-all" class="btn btn-ghost btn-sm calc-danger">Reset to defaults</button>
+          </div>
+        </div>
+
+        <!-- Global assumptions -->
+        <div class="calc-assumptions">
+          <div class="assume-field">
+            <label for="capex">Host build / lease-in cost (CAPEX)</label>
+            <div class="input-money">
+              <span class="prefix">$</span>
+              <input type="text" inputmode="numeric" id="capex" class="calc-num" />
+            </div>
+            <span class="assume-hint">Used for payback &amp; return-on-asset.</span>
+          </div>
+          <div class="assume-field">
+            <label for="days-year">On-hire days per year (max)</label>
+            <input type="text" inputmode="numeric" id="days-year" class="calc-num" />
+            <span class="assume-hint">365 for a full year; utilisation is applied per tenant.</span>
+          </div>
+        </div>
+
+        <!-- The spreadsheet -->
+        <div class="table-wrap calc-table-wrap">
+          <table class="calc-table" id="rate-table">
+            <thead>
+              <tr>
+                <th class="col-on"><abbr title="Include this tenant in the totals">On</abbr></th>
+                <th class="col-name">Tenant / use case</th>
+                <th class="col-in">Day rate<br><small>$/day</small></th>
+                <th class="col-in">Term<br><small>years</small></th>
+                <th class="col-in">Utilisation<br><small>%</small></th>
+                <th class="col-in">Operating cost<br><small>$/day</small></th>
+                <th class="col-calc">Revenue / yr</th>
+                <th class="col-calc">Net / yr</th>
+                <th class="col-calc">Net over term</th>
+                <th class="col-calc">Payback</th>
+                <th class="col-x" aria-label="Remove"></th>
+              </tr>
+            </thead>
+            <tbody id="rate-body"><!-- rows injected by JS --></tbody>
+            <tfoot>
+              <tr class="calc-total-row">
+                <td></td>
+                <td class="calc-total-label">Active tenants (blended)</td>
+                <td class="num" id="t-dayrate">—</td>
+                <td></td>
+                <td class="num" id="t-util">—</td>
+                <td></td>
+                <td class="num calc-calc" id="t-rev">—</td>
+                <td class="num calc-calc" id="t-net">—</td>
+                <td class="num calc-calc" id="t-termnet">—</td>
+                <td class="num calc-calc" id="t-payback">—</td>
+                <td></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+        <p class="calc-foot-note" id="empty-note" hidden>
+          No tenants yet — add one from the list above to start modelling.
+        </p>
+
+        <!-- Comparison bars -->
+        <div class="calc-compare">
+          <h3 class="subhead">Net revenue per year — compare tenants</h3>
+          <div id="compare-bars" class="compare-bars"><!-- bars injected by JS --></div>
+        </div>
+
+        <p class="hull-note calc-disclaimer">
+          Illustrative model for discussion only. Day rates, terms, utilisation, operating costs and CAPEX
+          are placeholder defaults you can edit — they are not offers, quotes or guarantees. Net revenue is
+          shown before financing, tax and mobilisation. Payback is CAPEX ÷ net revenue per year.
+        </p>
+      </div>
+    </section>
+
   </main>
 
   <!-- ===================== FOOTER ===================== -->


### PR DESCRIPTION
## What

Adds a narrative **"Lease vs. Build"** section to `day-rates.html`, positioned **above** the day-rate calculator so the market-opportunity case motivates the interactive model before the reader reaches it. Page order is now: intro → lease vs. build → calculator → disclaimer.

The section makes the case for a ready MPSS as leaseable infrastructure, and is built entirely from the site's existing components (`split`, `cards`, `matrix`, `pull-quote`) so it matches the rest of the design.

## Contents

- **Build-vs-lease split** — build your own host (slow, first-of-a-kind, capital-locked) vs. lease a ready MPSS (classed, ~14-month delivery, capex→opex, first oil pulled forward).
- **The case in four cards** — you're selling schedule; the long-tail addressable field set; the existing floating-production leasing market (FPSO precedent); scarcity / bidding-war dynamics.
- **"Who leases, and why" matrix** — independents, NOCs, majors' marginal fields, redevelopments/tiebacks, and any operator in a tight yard market.
- **"What a sharp buyer will push on"** — an honest treatment of the two real pushbacks: financing steel on spec, and field fit.

Copy uses the figures already on the site (LR/ABS/DNV approval, ~14-month hull, 15,000 t payload, 37.5 m survival wave).

## Notes

- Static-site change only — no new dependencies or assets.
- HTML validated as well-formed; all CSS classes used are already defined in `styles.css`.

## Commits

- Add lease-vs-build market-opportunity section to day-rate page
- Move lease-vs-build section above the day-rate calculator (updates the "model above" reference to "model below")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7WWgjLHLPBwmpXGyR6B2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7WWgjLHLPBwmpXGyR6B2d)_