### PR TITLE
Add individualized family-office & infrastructure outreach letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ For the `seaways-mpss.com` domain, point the host at this repository / folder.
 - Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no
   third-party chart images), so they're safe to edit and reuse.
 - Key figures (30,000+ Lt payload — 90X reference hull, ~10,000 Lt hull steel — over 40,000 Lt virtual mass (water ballast), 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,
-  ~14-month hull delivery, LR/ABS/DNV approval) and the design heritage are drawn from
+  ~14-month hull delivery, 100+ year predicted service life (Faulkner), LR/ABS/DNV approval) and the design heritage are drawn from
   Seaways Engineering source material.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ For the `seaways-mpss.com` domain, point the host at this repository / folder.
 - **Copy** lives inline in `index.html`, grouped by clearly-commented sections.
 - Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no
   third-party chart images), so they're safe to edit and reuse.
-- Key figures (30,000+ Lt payload — 90X reference hull, ~10,000 Lt hull steel — 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,
+- Key figures (30,000+ Lt payload — 90X reference hull, ~10,000 Lt hull steel — over 40,000 Lt virtual mass (water ballast), 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,
   ~14-month hull delivery, LR/ABS/DNV approval) and the design heritage are drawn from
   Seaways Engineering source material.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ For the `seaways-mpss.com` domain, point the host at this repository / folder.
 - **Copy** lives inline in `index.html`, grouped by clearly-commented sections.
 - Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no
   third-party chart images), so they're safe to edit and reuse.
-- Key figures (15,000 t payload, 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,
+- Key figures (30,000+ Lt payload — 90X reference hull, ~10,000 Lt hull steel — 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,
   ~14-month hull delivery, LR/ABS/DNV approval) and the design heritage are drawn from
   Seaways Engineering source material.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Seaways MPSS — The Multi-Purpose Semi-Submersible</title>
-  <meta name="description" content="LANG's MPSS is a validated, standardized Multi-Purpose Semi-Submersible: a five-S design — Simple, Safe, Swift, Size, Saves. A 15,000-tonne-payload deepwater production host, approved by Lloyd's Register, ABS and DNV, that turns the floating host from a bespoke project into leaseable offshore infrastructure." />
+  <meta name="description" content="LANG's MPSS is a validated, standardized Multi-Purpose Semi-Submersible: a five-S design — Simple, Safe, Swift, Size, Saves. A 30,000-plus-long-ton-payload deepwater production host, approved by Lloyd's Register, ABS and DNV, that turns the floating host from a bespoke project into leaseable offshore infrastructure." />
   <meta name="theme-color" content="#0a1a2f" />
 
   <meta property="og:type" content="website" />
@@ -109,7 +109,7 @@
           <a href="#contact" class="btn btn-ghost">Talk to us</a>
         </div>
         <ul class="hero-stats">
-          <li><span class="stat-num">15,000 t</span><span class="stat-label">deck payload</span></li>
+          <li><span class="stat-num">30,000+ Lt</span><span class="stat-label">deck payload</span></li>
           <li><span class="stat-num">8,100 m²</span><span class="stat-label">open deck</span></li>
           <li><span class="stat-num">14 months</span><span class="stat-label">hull delivery</span></li>
           <li><span class="stat-num">LR · ABS · DNV</span><span class="stat-label">approved</span></li>
@@ -203,7 +203,7 @@
         <p class="lead light">Specifications for the reference MPSS host.</p>
 
         <div class="specs-grid">
-          <div class="spec"><span class="spec-num">15,000<small>t</small></span><span class="spec-label">Deck payload, 5&nbsp;m above deck — deck weight not counted</span></div>
+          <div class="spec"><span class="spec-num">30,000+<small>Lt</small></span><span class="spec-label">Deck payload, 5&nbsp;m above deck — deck weight not counted</span></div>
           <div class="spec"><span class="spec-num">8,100<small>m²</small></span><span class="spec-label">Large, open, uncrowded deck</span></div>
           <div class="spec"><span class="spec-num">2M<small>bbl</small></span><span class="spec-label">Optional onboard oil storage (SWIS configuration)</span></div>
           <div class="spec"><span class="spec-num">37.5<small>m</small></span><span class="spec-label">Survival wave tested — 123&nbsp;ft, no water on deck</span></div>
@@ -212,6 +212,7 @@
         </div>
 
         <ul class="spec-notes">
+          <li>Hull just under 10,000&nbsp;Lt of steel carries 30,000+&nbsp;Lt of payload — roughly a 3:1 payload-to-steel ratio</li>
           <li>Steel Catenary Riser (SCR) system — dry-tree capable, longer life, lower cost than flexible hose</li>
           <li>Skid-on / skid-off topsides — reconfigurable for changing field needs</li>
           <li>Seawater-flooded pontoons for ballast — not a pressure vessel, higher payload, lower cost</li>
@@ -451,7 +452,7 @@
               <tr><td>Standardization</td><td>The same hull, adapted by topside package</td></tr>
               <tr><td>Capital efficiency</td><td>Lower hull cost, lower labor per tonne, faster revenue</td></tr>
               <tr><td>Contracting flexibility</td><td>Lease, bareboat, JV, or sale options</td></tr>
-              <tr><td>Host payload &amp; deck</td><td>15,000&nbsp;t payload on a large, stable, open deck</td></tr>
+              <tr><td>Host payload &amp; deck</td><td>30,000+&nbsp;Lt payload on a large, stable, open deck</td></tr>
               <tr><td>Number of subsea tiebacks</td><td>Low-motion host strengthens the SCR / cable / riser support case</td></tr>
               <tr><td>Onboard storage</td><td>Up to 2&nbsp;M&nbsp;bbl in the SWIS configuration — FPSO capability</td></tr>
             </tbody>

--- a/index.html
+++ b/index.html
@@ -481,6 +481,7 @@
             <ul class="ticks">
               <li>Classification review by Lloyd's Register, ABS &amp; DNV</li>
               <li>Design evaluated and endorsed by Prof. Douglas Faulkner, University of Glasgow</li>
+              <li>100+ year predicted service life on simple in-field maintenance (Prof. Douglas Faulkner)</li>
               <li>Peer-reviewed: "Design Evaluation of a Multi-Purpose Semisubmersible" (Faulkner, Incecik &amp; Lang)</li>
               <li>Lloyd's certification covering primary structure, stability, mooring &amp; ballast systems</li>
             </ul>
@@ -524,7 +525,10 @@
             <h3>Second-life &amp; residual value</h3>
             <p>The MPSS keeps accepting work after first production — added tiebacks, extra modules, brownfield
               debottlenecking, power, compression, CCS, hydrogen, or float-off / float-on redeployment to a new
-              field. That optionality supports high residual value.</p>
+              field. With a 100+ year predicted service life (Prof. Douglas Faulkner) — renewed by simple
+              in-field maintenance: deballast the affected section clear of the water, then paint, repair or
+              replace, no drydock — that optionality plays out across five or six lease cycles, supporting
+              high residual value.</p>
           </article>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -144,7 +144,8 @@
           <article class="card">
             <h3>Low-motion by design</h3>
             <p>A deep-draft ring pontoon sees roughly 40% of surface wave height at 27 m, giving very low
-              heave response — effectively motionless in sub-12&nbsp;m seas.</p>
+              heave response — effectively motionless in sub-12&nbsp;m seas. Over 40,000&nbsp;Lt of water
+              ballast gives the hull an enormous virtual (added) mass — the physics behind the low motion.</p>
           </article>
         </div>
       </div>
@@ -168,7 +169,8 @@
           <article class="s-card">
             <span class="s-letter">S</span>
             <h3>Safe</h3>
-            <p>A massive reserve of buoyancy — a "safety belt" of ballast at sea level. Watertight subdivision
+            <p>A massive reserve of buoyancy — a "safety belt" of over 40,000&nbsp;Lt of water ballast at sea
+              level, for an enormous virtual mass. Watertight subdivision
               throughout and inherent flood-damage capability. Tested to a 37.5&nbsp;m (123&nbsp;ft) storm wave with
               no water on deck, no emergency draft, and broken-mooring survival.</p>
           </article>
@@ -216,6 +218,7 @@
           <li>Steel Catenary Riser (SCR) system — dry-tree capable, longer life, lower cost than flexible hose</li>
           <li>Skid-on / skid-off topsides — reconfigurable for changing field needs</li>
           <li>Seawater-flooded pontoons for ballast — not a pressure vessel, higher payload, lower cost</li>
+          <li>Over 40,000&nbsp;Lt of water ballast — a large virtual (added) mass that damps motion</li>
           <li>Gravity-based de-ballast and small-capacity ferryboat-style trim system</li>
         </ul>
       </div>

--- a/outreach/README.md
+++ b/outreach/README.md
@@ -1,0 +1,51 @@
+# MPSS — Family Office & Infrastructure Outreach
+
+Individually written invitations for a **15-minute call with a decision-maker**.
+Each letter is tailored to what the recipient has actually done, and leads with the
+MPSS use-case closest to their thesis.
+
+## The three asks (calibrated per target — don't over-offer)
+
+| Ask | Amount | Best aimed at |
+|-----|--------|---------------|
+| **A. Seed / runway** | ~$4M, funds a 2-year runway to first LOI + fabrication-ready | Tier 3 direct-invest family offices, patient capital |
+| **B. First-hull equity** | ~$50M anchor equity to build **MPSS 001** | Tier 1 infra managers, Pritzker-class direct investors |
+| **C. Joint venture** | Hull-owning JV / co-build platform | Tier 1 + institutional / sovereign infra arms |
+
+**Rule of thumb:** offer the smallest thing that fits. Smaller offices → the seed.
+Big infra balance sheets → the build or a JV. We are not sure how deep demand runs,
+so no letter dangles board control, large equity, or exclusivity. The letters sell a
+*conversation*, not terms.
+
+## Files
+
+- `tier-1-infrastructure-managers.md` — Brookfield, Stonepeak, GIP, Mubadala, Blackstone Infrastructure, Centerbridge
+- `tier-2-institutional-sovereign.md` — Pritzker, PIF, KIA, QIA, ADIA, Temasek, CPPIB, Ontario Teachers', CDPQ, Khazanah
+- `tier-3-direct-invest-family-offices.md` — Tillery, Preservation Holdings, Brydon, Anchor, Compass Diversified, DCA, European maritime offices
+
+## The shared MPSS facts every letter can stand on
+
+- **Validated, standardized** deepwater host — approved by **Lloyd's Register, ABS and DNV** (primary structure, intact & damaged stability, mooring, ballast).
+- **15,000 t** deck payload · **8,100 m²** open deck · **~14-month** hull delivery · single operating draft.
+- **Low-motion** deep-draft ring pontoon — effectively motionless in sub-12 m seas; tested to a **37.5 m (123 ft)** survival wave with no water on deck.
+- **One hull, any mission** — the topside package changes, not the hull.
+- **Re-lettable across industries** — the AerCap "own the asset, lease it, refinance across lessees" template, applied to a 50–70-year marine asset.
+
+### The use-case / day-rate menu (illustrative)
+
+| Use case | Day rate | Typical term |
+|----------|----------|--------------|
+| Oil production host (FPSO / SWIS, up to 2M bbl storage) | ~$350k/day | 8 yr |
+| Drilling / **tender-assist** support | ~$300k/day | 3 yr |
+| **Workover / well intervention** | (production-adjacent) | campaign |
+| **Turbine Plus** — offshore wind turbine install / power island | ~$180k/day | 2 yr |
+| Offshore data center | ~$220k/day | 10 yr |
+| Power generation | ~$160k/day | 10 yr |
+| CCS / carbon storage | ~$200k/day | 12 yr |
+| Green hydrogen | ~$210k/day | 10 yr |
+| **Accommodation / flotel** | ~$120k/day | 2 yr |
+| **Marginal-field** development host | field-dependent | field life |
+
+## Sender
+
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com · seaways-mpss.com

--- a/outreach/README.md
+++ b/outreach/README.md
@@ -26,7 +26,7 @@ so no letter dangles board control, large equity, or exclusivity. The letters se
 ## The shared MPSS facts every letter can stand on
 
 - **Validated, standardized** deepwater host — approved by **Lloyd's Register, ABS and DNV** (primary structure, intact & damaged stability, mooring, ballast).
-- **15,000 t** deck payload · **8,100 m²** open deck · **~14-month** hull delivery · single operating draft.
+- **30,000+ Lt** deck payload (long tons; 90X reference hull) on a hull of **just under 10,000 Lt** of steel — a ~3:1 payload-to-steel ratio · **8,100 m²** open deck · **~14-month** hull delivery · single operating draft.
 - **Low-motion** deep-draft ring pontoon — effectively motionless in sub-12 m seas; tested to a **37.5 m (123 ft)** survival wave with no water on deck.
 - **One hull, any mission** — the topside package changes, not the hull.
 - **Re-lettable across industries** — the AerCap "own the asset, lease it, refinance across lessees" template, applied to a 50–70-year marine asset.

--- a/outreach/README.md
+++ b/outreach/README.md
@@ -27,7 +27,7 @@ so no letter dangles board control, large equity, or exclusivity. The letters se
 
 - **Validated, standardized** deepwater host — approved by **Lloyd's Register, ABS and DNV** (primary structure, intact & damaged stability, mooring, ballast).
 - **30,000+ Lt** deck payload (long tons; 90X reference hull) on a hull of **just under 10,000 Lt** of steel — a ~3:1 payload-to-steel ratio · **8,100 m²** open deck · **~14-month** hull delivery · single operating draft.
-- **Low-motion** deep-draft ring pontoon — effectively motionless in sub-12 m seas; tested to a **37.5 m (123 ft)** survival wave with no water on deck.
+- **Low-motion** deep-draft ring pontoon — over **40,000 Lt** of water ballast gives the hull an enormous virtual (added) mass, so it's effectively motionless in sub-12 m seas; tested to a **37.5 m (123 ft)** survival wave with no water on deck.
 - **One hull, any mission** — the topside package changes, not the hull.
 - **Re-lettable across industries** — the AerCap "own the asset, lease it, refinance across lessees" template, applied to a 50–70-year marine asset.
 

--- a/outreach/README.md
+++ b/outreach/README.md
@@ -29,7 +29,8 @@ so no letter dangles board control, large equity, or exclusivity. The letters se
 - **30,000+ Lt** deck payload (long tons; 90X reference hull) on a hull of **just under 10,000 Lt** of steel — a ~3:1 payload-to-steel ratio · **8,100 m²** open deck · **~14-month** hull delivery · single operating draft.
 - **Low-motion** deep-draft ring pontoon — over **40,000 Lt** of water ballast gives the hull an enormous virtual (added) mass, so it's effectively motionless in sub-12 m seas; tested to a **37.5 m (123 ft)** survival wave with no water on deck.
 - **One hull, any mission** — the topside package changes, not the hull.
-- **Re-lettable across industries** — the AerCap "own the asset, lease it, refinance across lessees" template, applied to a 50–70-year marine asset.
+- **Re-lettable across industries** — the AerCap "own the asset, lease it, refinance across lessees" template, applied to a **100+ year** marine asset (Prof. Douglas Faulkner's predicted service life).
+- **In-field maintenance, no drydock** — deballast the affected section clear of the water, then paint, repair or replace whatever's needed, and it's good as new. That renewability is what sustains the 100+ year life and the residual value across five or six lease cycles.
 
 ### The use-case / day-rate menu (illustrative)
 

--- a/outreach/tier-1-infrastructure-managers.md
+++ b/outreach/tier-1-infrastructure-managers.md
@@ -1,0 +1,155 @@
+# Tier 1 — Infrastructure Managers / Family-Office Anchors
+
+Big balance sheets, marine/energy precedent, family-office LP bases. Lead with a **JV or
+first-hull anchor equity (Ask B/C)** — not the seed. Keep terms out of the letter; sell the call.
+
+---
+
+## 1. Brookfield (Infrastructure / BISS)
+
+**To:** Brookfield Infrastructure — Business Development / Origination
+**Subject:** A standardized, leaseable offshore host — the middle-market infrastructure asset behind BISS
+
+Dear [Name],
+
+Brookfield just closed a ~$1B middle-market vehicle in BISS, and you sit on an LP base of
+roughly 200 family offices that want infrastructure cash flow without bespoke project risk.
+I'd like 15 minutes to show you an asset built exactly for that box.
+
+The MPSS is a validated, standardized deepwater host — approved by Lloyd's Register, ABS and
+DNV — that we lease rather than sell. One 15,000-tonne hull, re-let across production, floating
+wind (our "Turbine Plus" install and power-island configuration), accommodation, power and CCS,
+on 10–15 year charters at ~$120k–$350k/day against a 50–70-year asset life. It is FPSO-grade
+bankability with aircraft-leasing re-lettability: the AerCap template, in steel, at sea.
+
+The first hull is a ~$50M anchor-equity ticket — deliberately middle-market, deliberately
+repeatable. I think it fits BISS better than it fits anyone.
+
+Could we find 15 minutes in the next two weeks? I'll bring the class approvals and the
+charter economics, nothing to sign.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 2. Stonepeak Infrastructure Partners
+
+**To:** Stonepeak — Energy Transition / Origination
+**Subject:** Floating host for offshore wind + power — a re-lettable hull, not a one-off FPU
+
+Dear [Name],
+
+Stonepeak's energy-transition thesis and your work alongside GIP on Revolution Wind tell me
+you already believe the value in offshore is moving from the wellhead to the platform. The MPSS
+is the platform — decoupled from any single field or wind lease.
+
+It's a standardized, LR/ABS/DNV-approved semi-submersible host. The same low-motion hull
+installs turbines and hosts a floating power/HVDC island ("Turbine Plus"), then re-lets to
+CCS, hydrogen, power or production as leases roll — 10–15 year charters, 50–70 year hull.
+Because it's a product and not a project, the delivery and residual-value risk that kills
+bespoke FPUs largely disappears.
+
+Given your explicit family-office mandate and infrastructure-leasing playbook, I'd value 15
+minutes to discuss a hull-owning JV or anchor equity in the first unit. No terms, just the case.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 3. Global Infrastructure Partners (GIP)
+
+**To:** GIP — Energy / Offshore
+**Subject:** The re-deployable offshore host behind your wind and ports thesis
+
+Dear [Name],
+
+GIP has put real capital into offshore wind (including the Revolution Wind partnership) and
+into ports and energy infrastructure that live for decades. The MPSS extends that logic to the
+one piece of offshore that is still built bespoke every time: the floating host.
+
+We standardized it. It's LR/ABS/DNV-approved, delivers in ~14 months, carries 15,000 t on
+8,100 m² of open deck, and is effectively motionless in sub-12 m seas. The same hull installs
+wind turbines and carries a power/HVDC island, then re-lets to production, CCS or hydrogen —
+a genuinely re-deployable, float-off/float-on asset rather than a stranded one.
+
+I'd like 15 minutes to explore where this fits GIP — a first-hull co-build or a JV. I'll come
+with the classification file and charter economics.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 4. Mubadala
+
+**To:** Mubadala — Energy / Infrastructure
+**Subject:** Floating-platform capacity that de-risks O&G while it builds power & wind
+
+Dear [Name],
+
+Your $6.1B Hornsea 3 co-investment with Apollo made Mubadala's direction clear: keep the
+energy returns, move the exposure toward floating power and offshore wind. The MPSS is a single
+asset that lets you do both at once.
+
+It is a validated, standardized, LR/ABS/DNV-approved host. One low-motion hull hosts deepwater
+production and up to 2M bbl of storage today (declining but cash-rich), installs wind turbines
+and carries a floating power/HVDC island tomorrow ("Turbine Plus"), and re-lets to CCS and
+hydrogen after that — 50–70 year life, 10–15 year charters. It is the physical hedge your
+transition thesis is already paying for in bespoke form.
+
+I'd welcome 15 minutes with the right person on your team to discuss a JV or anchor equity in
+the first hull. I'll bring approvals and economics, nothing to sign.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 5. Blackstone Infrastructure
+
+**To:** Blackstone Infrastructure — Origination
+**Subject:** Marine leasing as an asset class — the offshore parallel to Safe Harbor Marinas
+
+Dear [Name],
+
+Blackstone's ~$5.6B move into Safe Harbor Marinas said something the rest of the market is
+slow to price: standardized marine assets with contracted cash flow are infrastructure, and
+they compound. The MPSS applies that thesis one step out to sea.
+
+It's a validated, LR/ABS/DNV-approved deepwater host we lease, not sell — one 15,000-tonne hull
+re-let across production, floating wind ("Turbine Plus"), power, accommodation, data centers
+and CCS at ~$120k–$350k/day on 10–15 year charters, against a 50–70 year hull. Dry-lease,
+non-recourse, FPSO-template financing: the lender underwrites the charterer, not the concept —
+exactly the bankability profile your marina deal proved out.
+
+The first hull is a ~$50M anchor ticket, small by your standards and precisely why it's the
+right first proof point. Could we find 15 minutes?
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 6. Centerbridge Partners
+
+**To:** Centerbridge — Infrastructure / Real Assets
+**Subject:** Consolidating a fragmented marine asset class — from Suntex to offshore hulls
+
+Dear [Name],
+
+The ~$4B Suntex Marinas valuation showed Centerbridge saw the same pattern we do: a fragmented,
+capital-hungry marine asset class matures fast once someone standardizes and leases it. The
+offshore floating host is that class, pre-consolidation.
+
+The MPSS is the standard unit — LR/ABS/DNV-approved, 15,000 t payload, ~14-month delivery, and
+re-lettable across production, workover/tender-assist, accommodation, floating wind and power.
+Today every host is a bespoke build; we make it fleet inventory with contracted charters and
+real residual value. That's the arbitrage between a project and a product.
+
+I'd value 15 minutes to walk your team through the leasing economics and where Centerbridge
+could anchor — first-hull equity or a JV. Happy to work around your calendar.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com

--- a/outreach/tier-1-infrastructure-managers.md
+++ b/outreach/tier-1-infrastructure-managers.md
@@ -17,7 +17,7 @@ roughly 200 family offices that want infrastructure cash flow without bespoke pr
 I'd like 15 minutes to show you an asset built exactly for that box.
 
 The MPSS is a validated, standardized deepwater host — approved by Lloyd's Register, ABS and
-DNV — that we lease rather than sell. One 15,000-tonne hull, re-let across production, floating
+DNV — that we lease rather than sell. One hull carrying 30,000+ long tons of payload, re-let across production, floating
 wind (our "Turbine Plus" install and power-island configuration), accommodation, power and CCS,
 on 10–15 year charters at ~$120k–$350k/day against a 50–70-year asset life. It is FPSO-grade
 bankability with aircraft-leasing re-lettability: the AerCap template, in steel, at sea.
@@ -69,8 +69,9 @@ GIP has put real capital into offshore wind (including the Revolution Wind partn
 into ports and energy infrastructure that live for decades. The MPSS extends that logic to the
 one piece of offshore that is still built bespoke every time: the floating host.
 
-We standardized it. It's LR/ABS/DNV-approved, delivers in ~14 months, carries 15,000 t on
-8,100 m² of open deck, and is effectively motionless in sub-12 m seas. The same hull installs
+We standardized it. It's LR/ABS/DNV-approved, delivers in ~14 months, carries 30,000+ long tons
+on 8,100 m² of open deck (on a hull of just under 10,000 Lt of steel), and is effectively
+motionless in sub-12 m seas. The same hull installs
 wind turbines and carries a power/HVDC island, then re-lets to production, CCS or hydrogen —
 a genuinely re-deployable, float-off/float-on asset rather than a stranded one.
 
@@ -118,8 +119,8 @@ Blackstone's ~$5.6B move into Safe Harbor Marinas said something the rest of the
 slow to price: standardized marine assets with contracted cash flow are infrastructure, and
 they compound. The MPSS applies that thesis one step out to sea.
 
-It's a validated, LR/ABS/DNV-approved deepwater host we lease, not sell — one 15,000-tonne hull
-re-let across production, floating wind ("Turbine Plus"), power, accommodation, data centers
+It's a validated, LR/ABS/DNV-approved deepwater host we lease, not sell — one hull carrying
+30,000+ long tons of payload, re-let across production, floating wind ("Turbine Plus"), power, accommodation, data centers
 and CCS at ~$120k–$350k/day on 10–15 year charters, against a 50–70 year hull. Dry-lease,
 non-recourse, FPSO-template financing: the lender underwrites the charterer, not the concept —
 exactly the bankability profile your marina deal proved out.
@@ -143,7 +144,7 @@ The ~$4B Suntex Marinas valuation showed Centerbridge saw the same pattern we do
 capital-hungry marine asset class matures fast once someone standardizes and leases it. The
 offshore floating host is that class, pre-consolidation.
 
-The MPSS is the standard unit — LR/ABS/DNV-approved, 15,000 t payload, ~14-month delivery, and
+The MPSS is the standard unit — LR/ABS/DNV-approved, 30,000+ long tons of payload, ~14-month delivery, and
 re-lettable across production, workover/tender-assist, accommodation, floating wind and power.
 Today every host is a bespoke build; we make it fleet inventory with contracted charters and
 real residual value. That's the arbitrage between a project and a product.

--- a/outreach/tier-1-infrastructure-managers.md
+++ b/outreach/tier-1-infrastructure-managers.md
@@ -35,10 +35,10 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 
 ## 2. Stonepeak Infrastructure Partners
 
-**To:** Stonepeak — Energy Transition / Origination
+**To:** Michael Bricker — Senior Managing Director & Co-Head of Energy, Stonepeak
 **Subject:** Floating host for offshore wind + power — a re-lettable hull, not a one-off FPU
 
-Dear [Name],
+Dear Michael,
 
 Stonepeak's energy-transition thesis and your work alongside GIP on Revolution Wind tell me
 you already believe the value in offshore is moving from the wellhead to the platform. The MPSS
@@ -85,10 +85,10 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 
 ## 4. Mubadala
 
-**To:** Mubadala — Energy / Infrastructure
+**To:** Saed Arar — Head of Infrastructure, Mubadala
 **Subject:** Floating-platform capacity that de-risks O&G while it builds power & wind
 
-Dear [Name],
+Dear Saed,
 
 Your $6.1B Hornsea 3 co-investment with Apollo made Mubadala's direction clear: keep the
 energy returns, move the exposure toward floating power and offshore wind. The MPSS is a single
@@ -110,10 +110,10 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 
 ## 5. Blackstone Infrastructure
 
-**To:** Blackstone Infrastructure — Origination
+**To:** Sebastien Sherman — Senior Managing Director, Blackstone Infrastructure
 **Subject:** Marine leasing as an asset class — the offshore parallel to Safe Harbor Marinas
 
-Dear [Name],
+Dear Sebastien,
 
 Blackstone's ~$5.6B move into Safe Harbor Marinas said something the rest of the market is
 slow to price: standardized marine assets with contracted cash flow are infrastructure, and

--- a/outreach/tier-1-infrastructure-managers.md
+++ b/outreach/tier-1-infrastructure-managers.md
@@ -40,9 +40,10 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 
 Dear Michael,
 
-Stonepeak's energy-transition thesis and your work alongside GIP on Revolution Wind tell me
-you already believe the value in offshore is moving from the wellhead to the platform. The MPSS
-is the platform — decoupled from any single field or wind lease.
+Stonepeak already owns this thesis at sea — Textainer leases standardized steel boxes to some
+200 shipping lines, and Seapeak charters LNG carriers on long contracts. The MPSS is the same
+playbook one step further offshore: a standardized production host you own once and re-let for a
+century, decoupled from any single field or wind lease.
 
 It's a standardized, LR/ABS/DNV-approved semi-submersible host. The same low-motion hull
 installs turbines and hosts a floating power/HVDC island ("Turbine Plus"), then re-lets to

--- a/outreach/tier-1-infrastructure-managers.md
+++ b/outreach/tier-1-infrastructure-managers.md
@@ -19,7 +19,7 @@ I'd like 15 minutes to show you an asset built exactly for that box.
 The MPSS is a validated, standardized deepwater host — approved by Lloyd's Register, ABS and
 DNV — that we lease rather than sell. One hull carrying 30,000+ long tons of payload, re-let across production, floating
 wind (our "Turbine Plus" install and power-island configuration), accommodation, power and CCS,
-on 10–15 year charters at ~$120k–$350k/day against a 50–70-year asset life. It is FPSO-grade
+on 10–15 year charters at ~$120k–$350k/day against a 100+ year asset life. It is FPSO-grade
 bankability with aircraft-leasing re-lettability: the AerCap template, in steel, at sea.
 
 The first hull is a ~$50M anchor-equity ticket — deliberately middle-market, deliberately
@@ -46,7 +46,7 @@ is the platform — decoupled from any single field or wind lease.
 
 It's a standardized, LR/ABS/DNV-approved semi-submersible host. The same low-motion hull
 installs turbines and hosts a floating power/HVDC island ("Turbine Plus"), then re-lets to
-CCS, hydrogen, power or production as leases roll — 10–15 year charters, 50–70 year hull.
+CCS, hydrogen, power or production as leases roll — 10–15 year charters, 100+ year hull.
 Because it's a product and not a project, the delivery and residual-value risk that kills
 bespoke FPUs largely disappears.
 
@@ -97,7 +97,7 @@ asset that lets you do both at once.
 It is a validated, standardized, LR/ABS/DNV-approved host. One low-motion hull hosts deepwater
 production and up to 2M bbl of storage today (declining but cash-rich), installs wind turbines
 and carries a floating power/HVDC island tomorrow ("Turbine Plus"), and re-lets to CCS and
-hydrogen after that — 50–70 year life, 10–15 year charters. It is the physical hedge your
+hydrogen after that — 100+ year life, 10–15 year charters. It is the physical hedge your
 transition thesis is already paying for in bespoke form.
 
 I'd welcome 15 minutes with the right person on your team to discuss a JV or anchor equity in
@@ -121,7 +121,7 @@ they compound. The MPSS applies that thesis one step out to sea.
 
 It's a validated, LR/ABS/DNV-approved deepwater host we lease, not sell — one hull carrying
 30,000+ long tons of payload, re-let across production, floating wind ("Turbine Plus"), power, accommodation, data centers
-and CCS at ~$120k–$350k/day on 10–15 year charters, against a 50–70 year hull. Dry-lease,
+and CCS at ~$120k–$350k/day on 10–15 year charters, against a 100+ year hull. Dry-lease,
 non-recourse, FPSO-template financing: the lender underwrites the charterer, not the concept —
 exactly the bankability profile your marina deal proved out.
 

--- a/outreach/tier-2-institutional-sovereign.md
+++ b/outreach/tier-2-institutional-sovereign.md
@@ -15,8 +15,10 @@ frame, not the seed. **Pritzker** is the exception: a true direct-invest family 
 Dear Michael,
 
 PPC's model — direct acquisition, patient capital, 20-year-plus holds — is the rare fit for an
-asset whose whole thesis is a 50–70 year life. Most investors can't hold long enough to capture
-an MPSS hull's second and third lease cycles. You can.
+asset whose whole thesis is a 100+ year life — the span Prof. Douglas Faulkner predicted, held
+there by simple in-field maintenance (deballast the affected section clear of the water, then
+paint, repair or replace). Most investors can't hold long enough to capture an MPSS hull's
+fifth or sixth lease cycle. You can.
 
 It's a validated, standardized, LR/ABS/DNV-approved offshore host we lease rather than sell. One
 hull carrying 30,000+ long tons of payload re-lets across production, floating wind ("Turbine Plus"), accommodation,
@@ -65,7 +67,7 @@ Dear [Name],
 
 KIA's global infrastructure and energy mandate is built for assets that outlast any single
 project. The MPSS is one: a validated, standardized, LR/ABS/DNV-approved floating host with a
-50–70 year life that re-lets across offshore power, renewable install and production.
+100+ year life that re-lets across offshore power, renewable install and production.
 
 Rather than fund a bespoke platform tied to one field or one wind lease, KIA could hold
 standardized, contracted, re-deployable capacity — 10–15 year charters against a hull that
@@ -93,7 +95,7 @@ bespoke, the floating host.
 It's LR/ABS/DNV-approved, low-motion, 30,000+ long tons of payload, and re-configurable — turbine
 install and power/HVDC island today ("Turbine Plus"), production and storage where the economics
 are strong, CCS and hydrogen as they mature. One hull, adapted by its topside package, on
-long-term charters against a 50–70 year life.
+long-term charters against a 100+ year life.
 
 At QIA's scale the fit is a JV or platform co-invest. I'd welcome 15 minutes with your
 infrastructure team to explore it — approvals and economics in hand, nothing to sign.
@@ -115,7 +117,7 @@ capital a standardized floating-platform program needs. The MPSS turns the offsh
 bespoke, one-field build into a re-lettable, classed product with contracted cash flow.
 
 LR/ABS/DNV-approved, ~14-month delivery, 30,000+ long tons of payload, low-motion by design — one hull
-that carries production, floating wind ("Turbine Plus"), power and CCS across a 50–70 year life.
+that carries production, floating wind ("Turbine Plus"), power and CCS across a 100+ year life.
 For a long-horizon direct investor, the multi-cycle residual value is the point.
 
 I'd value 15 minutes to discuss a JV or anchor position with the right person on your team.
@@ -139,7 +141,7 @@ mass that keeps it effectively motionless in sub-12 m seas, and that survived a 
 with no water on deck.
 
 It's LR/ABS/DNV-approved and standardized — one hull for turbine install and power islands
-("Turbine Plus"), production, CCS and hydrogen, re-let across a 50–70 year life. It's a
+("Turbine Plus"), production, CCS and hydrogen, re-let across a 100+ year life. It's a
 climate-and-infrastructure asset that earns from the transition without betting on one project.
 
 I'd like 15 minutes to explore a JV or platform investment with your team. Approvals and
@@ -160,7 +162,7 @@ Dear [Name],
 CPP Investments underwrites infrastructure on long horizons and hard contracts — which is
 precisely how the MPSS is built to be owned. It's a validated, LR/ABS/DNV-approved floating
 host, leased on 10–15 year charters, re-lettable across production, floating wind, power and
-CCS, against a 50–70 year asset.
+CCS, against a 100+ year asset.
 
 The cash-flow profile is FPSO-grade with aircraft-leasing re-lettability: the lender
 underwrites the charterer, not the concept. That's the institutional-quality risk profile a
@@ -183,7 +185,7 @@ Dear [Name],
 
 Ontario Teachers' has long favored stable, contracted infrastructure held for decades. The MPSS
 fits that discipline: a standardized, LR/ABS/DNV-approved floating host on 10–15 year charters,
-re-let across production, floating wind ("Turbine Plus"), power and CCS, with a 50–70 year life
+re-let across production, floating wind ("Turbine Plus"), power and CCS, with a 100+ year life
 that carries real residual value into a second and third lease.
 
 It converts the offshore host from a bespoke project into an ownable, re-deployable asset —
@@ -210,7 +212,7 @@ classed hull that carries a power/HVDC island and installs turbines ("Turbine Pl
 re-lets to production, CCS or hydrogen.
 
 LR/ABS/DNV-approved, low-motion, 30,000+ long tons of payload, ~14-month delivery. It de-risks the part
-of your wind thesis that's still bespoke, and gives you a 50–70 year asset with multi-cycle
+of your wind thesis that's still bespoke, and gives you a 100+ year asset with multi-cycle
 residual value.
 
 I'd welcome 15 minutes with your infrastructure team to explore a JV or platform co-invest.
@@ -234,7 +236,7 @@ workover demand — all of which the MPSS serves from a single standardized hull
 It's LR/ABS/DNV-approved and re-configurable: production and storage for marginal-field
 development, tender-assist and workover support, accommodation/flotel, and turbine install /
 power islands ("Turbine Plus") as the region's wind build-out accelerates. One hull, many
-missions, a 50–70 year life.
+missions, a 100+ year life.
 
 I'd value 15 minutes to explore where this fits Khazanah — a JV or an anchor position in the
 first regional hull. Approvals and economics in hand.

--- a/outreach/tier-2-institutional-sovereign.md
+++ b/outreach/tier-2-institutional-sovereign.md
@@ -1,0 +1,242 @@
+# Tier 2 — Institutional / Sovereign Infrastructure & Direct-Invest Families
+
+Long-hold, transition-minded capital. For the sovereigns and pensions the single $50M hull is
+small — so these letters lead with a **JV / platform co-invest (Ask C)** and an energy-transition
+frame, not the seed. **Pritzker** is the exception: a true direct-invest family office where the
+**first-hull equity (Ask B)** fits cleanly.
+
+---
+
+## 1. Pritzker Private Capital (PPC)
+
+**To:** Pritzker Private Capital — Direct Investments
+**Subject:** A 50-year leaseable asset for 20-year-hold capital
+
+Dear [Name],
+
+PPC's model — direct acquisition, patient capital, 20-year-plus holds — is the rare fit for an
+asset whose whole thesis is a 50–70 year life. Most investors can't hold long enough to capture
+an MPSS hull's second and third lease cycles. You can.
+
+It's a validated, standardized, LR/ABS/DNV-approved offshore host we lease rather than sell. One
+15,000-tonne hull re-lets across production, floating wind ("Turbine Plus"), accommodation,
+power and CCS on 10–15 year charters at ~$120k–$350k/day. After the first charter pays down the
+debt, you own a deleveraged, re-lettable asset with decades of runway — terminal value that's a
+re-lease, not scrap.
+
+The first hull is a ~$50M anchor-equity ticket. I'd like 15 minutes to show you the class file
+and the multi-cycle economics. No terms on the table — just the shape of it.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 2. Saudi Public Investment Fund (PIF)
+
+**To:** PIF — Infrastructure / Energy Transition
+**Subject:** Standardized floating capacity for wind, HVDC and power at scale
+
+Dear [Name],
+
+PIF's build-out — floating wind, HVDC, offshore power — needs a floating host in volume, and
+today that host is engineered bespoke every single time. We standardized it, classed it, and
+made it re-deployable.
+
+The MPSS is LR/ABS/DNV-approved, delivers in ~14 months, and hosts wind-turbine installation
+and a floating power/HVDC island ("Turbine Plus"), then re-lets to production, CCS or hydrogen
+as your programs sequence. For a fund building offshore capacity at national scale, a
+repeatable hull is the difference between one-off projects and a fleet.
+
+At your scale the natural conversation isn't a single unit — it's a JV or a multi-hull platform.
+I'd value 15 minutes with the right team to explore it. I'll bring approvals and economics.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 3. Kuwait Investment Authority (KIA)
+
+**To:** KIA — Global Infrastructure
+**Subject:** Re-deployable offshore power infrastructure — one hull, many missions
+
+Dear [Name],
+
+KIA's global infrastructure and energy mandate is built for assets that outlast any single
+project. The MPSS is one: a validated, standardized, LR/ABS/DNV-approved floating host with a
+50–70 year life that re-lets across offshore power, renewable install and production.
+
+Rather than fund a bespoke platform tied to one field or one wind lease, KIA could hold
+standardized, contracted, re-deployable capacity — 10–15 year charters against a hull that
+keeps working long after the first lease pays it off.
+
+Given your scale, I'd frame this as a JV or platform co-investment. Could we find 15 minutes to
+walk through where it fits KIA's infrastructure book?
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 4. Qatar Investment Authority (QIA)
+
+**To:** QIA — Infrastructure / Energy
+**Subject:** Floating power-island capability for a diversified energy book
+
+Dear [Name],
+
+QIA's diversified infrastructure and energy positioning — including floating wind and HVDC —
+maps directly onto what the MPSS does: it standardizes the one offshore asset still built
+bespoke, the floating host.
+
+It's LR/ABS/DNV-approved, low-motion, 15,000-tonne payload, and re-configurable — turbine
+install and power/HVDC island today ("Turbine Plus"), production and storage where the economics
+are strong, CCS and hydrogen as they mature. One hull, adapted by its topside package, on
+long-term charters against a 50–70 year life.
+
+At QIA's scale the fit is a JV or platform co-invest. I'd welcome 15 minutes with your
+infrastructure team to explore it — approvals and economics in hand, nothing to sign.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 5. Abu Dhabi Investment Authority (ADIA)
+
+**To:** ADIA — Infrastructure
+**Subject:** Direct equity in standardized floating platforms
+
+Dear [Name],
+
+ADIA's appetite for direct infrastructure equity in energy and renewables is exactly the
+capital a standardized floating-platform program needs. The MPSS turns the offshore host from a
+bespoke, one-field build into a re-lettable, classed product with contracted cash flow.
+
+LR/ABS/DNV-approved, ~14-month delivery, 15,000-tonne payload, low-motion by design — one hull
+that carries production, floating wind ("Turbine Plus"), power and CCS across a 50–70 year life.
+For a long-horizon direct investor, the multi-cycle residual value is the point.
+
+I'd value 15 minutes to discuss a JV or anchor position with the right person on your team.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 6. Temasek
+
+**To:** Temasek — Energy & Resources / Climate
+**Subject:** From Green Volt to a standardized floating host that fits any sea state
+
+Dear [Name],
+
+Temasek's floating-wind exposure (Green Volt among them) shows you already back offshore
+capacity in motion-heavy waters. The MPSS is the host built for exactly that problem: a
+deep-draft ring pontoon that stays effectively motionless in sub-12 m seas and has survived a
+37.5 m test wave with no water on deck.
+
+It's LR/ABS/DNV-approved and standardized — one hull for turbine install and power islands
+("Turbine Plus"), production, CCS and hydrogen, re-let across a 50–70 year life. It's a
+climate-and-infrastructure asset that earns from the transition without betting on one project.
+
+I'd like 15 minutes to explore a JV or platform investment with your team. Approvals and
+economics in hand.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 7. Canada Pension Plan Investment Board (CPPIB)
+
+**To:** CPP Investments — Infrastructure / Energy Transition
+**Subject:** Institutional-scale, contracted offshore infrastructure with a 50-year life
+
+Dear [Name],
+
+CPP Investments underwrites infrastructure on long horizons and hard contracts — which is
+precisely how the MPSS is built to be owned. It's a validated, LR/ABS/DNV-approved floating
+host, leased on 10–15 year charters, re-lettable across production, floating wind, power and
+CCS, against a 50–70 year asset.
+
+The cash-flow profile is FPSO-grade with aircraft-leasing re-lettability: the lender
+underwrites the charterer, not the concept. That's the institutional-quality risk profile a
+plan your size can scale into a multi-hull position.
+
+I'd value 15 minutes to walk your infrastructure team through the economics and a platform-scale
+structure. Happy to work around your calendar.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 8. Ontario Teachers' Pension Plan
+
+**To:** Ontario Teachers' — Infrastructure & Natural Resources
+**Subject:** Stable, contracted offshore capacity for long-hold capital
+
+Dear [Name],
+
+Ontario Teachers' has long favored stable, contracted infrastructure held for decades. The MPSS
+fits that discipline: a standardized, LR/ABS/DNV-approved floating host on 10–15 year charters,
+re-let across production, floating wind ("Turbine Plus"), power and CCS, with a 50–70 year life
+that carries real residual value into a second and third lease.
+
+It converts the offshore host from a bespoke project into an ownable, re-deployable asset —
+which is what makes it hold-able for a pension rather than a project sponsor.
+
+Could we find 15 minutes for me to take your team through the charter economics and a platform
+structure? Approvals in hand, nothing to sign.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 9. Caisse de dépôt et placement du Québec (CDPQ)
+
+**To:** CDPQ — Infrastructure
+**Subject:** European offshore-wind exposure with a re-deployable host underneath it
+
+Dear [Name],
+
+CDPQ's European offshore-wind and HVDC exposure gives you a clear view of where the cost and
+schedule risk actually sits: the floating host and substation. The MPSS standardizes both — a
+classed hull that carries a power/HVDC island and installs turbines ("Turbine Plus"), then
+re-lets to production, CCS or hydrogen.
+
+LR/ABS/DNV-approved, low-motion, 15,000-tonne payload, ~14-month delivery. It de-risks the part
+of your wind thesis that's still bespoke, and gives you a 50–70 year asset with multi-cycle
+residual value.
+
+I'd welcome 15 minutes with your infrastructure team to explore a JV or platform co-invest.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 10. Khazanah Nasional
+
+**To:** Khazanah — Infrastructure / Energy
+**Subject:** Standardized floating host for Southeast Asian energy & renewables
+
+Dear [Name],
+
+Khazanah's positioning across Southeast Asian infrastructure, energy and renewables sits right
+on top of a region full of marginal fields, growing offshore wind, and accommodation and
+workover demand — all of which the MPSS serves from a single standardized hull.
+
+It's LR/ABS/DNV-approved and re-configurable: production and storage for marginal-field
+development, tender-assist and workover support, accommodation/flotel, and turbine install /
+power islands ("Turbine Plus") as the region's wind build-out accelerates. One hull, many
+missions, a 50–70 year life.
+
+I'd value 15 minutes to explore where this fits Khazanah — a JV or an anchor position in the
+first regional hull. Approvals and economics in hand.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com

--- a/outreach/tier-2-institutional-sovereign.md
+++ b/outreach/tier-2-institutional-sovereign.md
@@ -9,10 +9,10 @@ frame, not the seed. **Pritzker** is the exception: a true direct-invest family 
 
 ## 1. Pritzker Private Capital (PPC)
 
-**To:** Pritzker Private Capital — Direct Investments
+**To:** Michael Nelson — Managing Partner, Pritzker Private Capital
 **Subject:** A 50-year leaseable asset for 20-year-hold capital
 
-Dear [Name],
+Dear Michael,
 
 PPC's model — direct acquisition, patient capital, 20-year-plus holds — is the rare fit for an
 asset whose whole thesis is a 50–70 year life. Most investors can't hold long enough to capture
@@ -127,10 +127,10 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 
 ## 6. Temasek
 
-**To:** Temasek — Energy & Resources / Climate
+**To:** Uwe Krueger — Head of Industrials, Business Services, Energy & Resources, Temasek
 **Subject:** From Green Volt to a standardized floating host that fits any sea state
 
-Dear [Name],
+Dear Uwe,
 
 Temasek's floating-wind exposure (Green Volt among them) shows you already back offshore
 capacity in motion-heavy waters. The MPSS is the host built for exactly that problem: a

--- a/outreach/tier-2-institutional-sovereign.md
+++ b/outreach/tier-2-institutional-sovereign.md
@@ -19,7 +19,7 @@ asset whose whole thesis is a 50–70 year life. Most investors can't hold long 
 an MPSS hull's second and third lease cycles. You can.
 
 It's a validated, standardized, LR/ABS/DNV-approved offshore host we lease rather than sell. One
-15,000-tonne hull re-lets across production, floating wind ("Turbine Plus"), accommodation,
+hull carrying 30,000+ long tons of payload re-lets across production, floating wind ("Turbine Plus"), accommodation,
 power and CCS on 10–15 year charters at ~$120k–$350k/day. After the first charter pays down the
 debt, you own a deleveraged, re-lettable asset with decades of runway — terminal value that's a
 re-lease, not scrap.
@@ -90,7 +90,7 @@ QIA's diversified infrastructure and energy positioning — including floating w
 maps directly onto what the MPSS does: it standardizes the one offshore asset still built
 bespoke, the floating host.
 
-It's LR/ABS/DNV-approved, low-motion, 15,000-tonne payload, and re-configurable — turbine
+It's LR/ABS/DNV-approved, low-motion, 30,000+ long tons of payload, and re-configurable — turbine
 install and power/HVDC island today ("Turbine Plus"), production and storage where the economics
 are strong, CCS and hydrogen as they mature. One hull, adapted by its topside package, on
 long-term charters against a 50–70 year life.
@@ -114,7 +114,7 @@ ADIA's appetite for direct infrastructure equity in energy and renewables is exa
 capital a standardized floating-platform program needs. The MPSS turns the offshore host from a
 bespoke, one-field build into a re-lettable, classed product with contracted cash flow.
 
-LR/ABS/DNV-approved, ~14-month delivery, 15,000-tonne payload, low-motion by design — one hull
+LR/ABS/DNV-approved, ~14-month delivery, 30,000+ long tons of payload, low-motion by design — one hull
 that carries production, floating wind ("Turbine Plus"), power and CCS across a 50–70 year life.
 For a long-horizon direct investor, the multi-cycle residual value is the point.
 
@@ -208,7 +208,7 @@ schedule risk actually sits: the floating host and substation. The MPSS standard
 classed hull that carries a power/HVDC island and installs turbines ("Turbine Plus"), then
 re-lets to production, CCS or hydrogen.
 
-LR/ABS/DNV-approved, low-motion, 15,000-tonne payload, ~14-month delivery. It de-risks the part
+LR/ABS/DNV-approved, low-motion, 30,000+ long tons of payload, ~14-month delivery. It de-risks the part
 of your wind thesis that's still bespoke, and gives you a 50–70 year asset with multi-cycle
 residual value.
 

--- a/outreach/tier-2-institutional-sovereign.md
+++ b/outreach/tier-2-institutional-sovereign.md
@@ -10,7 +10,7 @@ frame, not the seed. **Pritzker** is the exception: a true direct-invest family 
 ## 1. Pritzker Private Capital (PPC)
 
 **To:** Michael Nelson — Managing Partner, Pritzker Private Capital
-**Subject:** A 50-year leaseable asset for 20-year-hold capital
+**Subject:** A 100-year leaseable asset for 20-year-hold capital
 
 Dear Michael,
 

--- a/outreach/tier-2-institutional-sovereign.md
+++ b/outreach/tier-2-institutional-sovereign.md
@@ -134,8 +134,9 @@ Dear [Name],
 
 Temasek's floating-wind exposure (Green Volt among them) shows you already back offshore
 capacity in motion-heavy waters. The MPSS is the host built for exactly that problem: a
-deep-draft ring pontoon that stays effectively motionless in sub-12 m seas and has survived a
-37.5 m test wave with no water on deck.
+deep-draft ring pontoon carrying over 40,000 long tons of water ballast — an enormous virtual
+mass that keeps it effectively motionless in sub-12 m seas, and that survived a 37.5 m test wave
+with no water on deck.
 
 It's LR/ABS/DNV-approved and standardized — one hull for turbine install and power islands
 ("Turbine Plus"), production, CCS and hydrogen, re-let across a 50–70 year life. It's a

--- a/outreach/tier-3-direct-invest-family-offices.md
+++ b/outreach/tier-3-direct-invest-family-offices.md
@@ -1,0 +1,173 @@
+# Tier 3 — Direct-Invest Family Offices (Patient Capital, $500M–$5B)
+
+The natural home for **Ask A — the ~$4M seed / 2-year runway**, with the ~$50M first hull
+(Ask B) held in reserve for the ones that lean in. These offices move fast, hold long, and don't
+need an energy-company gate to say yes. Keep the offer modest — the seed buys us to first LOI and
+fabrication-ready; nothing larger is on the table in the first call.
+
+---
+
+## 1. Tillery Capital Partners
+
+**To:** Tillery Capital Partners
+**Subject:** Getting in early on standardized offshore infrastructure — a $4M seed
+
+Dear [Name],
+
+Tillery works the lower-middle-market with an infrastructure lean — which is exactly the entry
+point for the MPSS before it becomes a fleet. We've validated and classed (Lloyd's, ABS, DNV) a
+standardized deepwater host that gets leased, not sold: one hull, re-let across production,
+workover, accommodation, floating wind and power at ~$120k–$350k/day over 10–15 year charters.
+
+The heavy engineering and independent validation are behind us. What we're raising now is a
+modest **$4M seed** for a two-year runway — to first charter LOI and a fabrication-ready first
+hull. It's a small ticket into an asset with a 50–70 year life and a leasing model borrowed
+straight from aircraft.
+
+Could I have 15 minutes to walk you through it? Nothing to sign — just the case and the numbers.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 2. Preservation Holdings
+
+**To:** Preservation Holdings
+**Subject:** A 50-year asset for long-hold capital — early backing
+
+Dear [Name],
+
+The name says the thesis: preserve and compound over long horizons. The MPSS is built for that
+clock — a validated, LR/ABS/DNV-approved offshore host with a 50–70 year life, leased on 10–15
+year charters and re-let across production, accommodation, floating wind and power as each lease
+rolls. The residual value is a re-lease, not scrap.
+
+We're past the hard engineering and independent validation. The raise now is a modest **$4M
+seed** for a two-year runway to first LOI and a fabrication-ready hull — early backing into a
+multi-decade asset, on patient-capital terms that suit how you hold.
+
+I'd value 15 minutes to take you through it. Happy to work around your calendar.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 3. The Brydon Group
+
+**To:** The Brydon Group
+**Subject:** Infrastructure-vehicle backing for a standardized offshore host
+
+Dear [Name],
+
+Brydon's infrastructure-focused, operator-led approach is well suited to a business whose whole
+premise is turning a bespoke offshore project into a repeatable infrastructure product. The
+MPSS is validated and classed (Lloyd's, ABS, DNV); the hard part is done.
+
+One standardized hull, re-let across production, tender-assist and workover support,
+accommodation, and floating wind — 10–15 year charters, 50–70 year life. We're raising a modest
+**$4M seed** for a two-year runway to first LOI and fabrication-ready status, with the first
+~$50M hull the natural next step for backers who want to build from the ground floor.
+
+Could we find 15 minutes? I'll bring the class file and the charter economics.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 4. Anchor Investments
+
+**To:** Anchor Investments
+**Subject:** Ground-floor into leaseable offshore infrastructure
+
+Dear [Name],
+
+Given your infrastructure orientation, I wanted to put a genuinely early opportunity in front of
+you. The MPSS is a validated, LR/ABS/DNV-approved deepwater host we lease rather than sell — one
+15,000-tonne hull re-let across production, accommodation, floating wind ("Turbine Plus") and
+power at ~$120k–$350k/day, against a 50–70 year life.
+
+The engineering and independent validation are complete. We're raising a modest **$4M seed** for
+a two-year runway to first charter LOI and a fabrication-ready first hull — a small ticket into
+an asset class (marine leasing) that's institutionalizing quickly.
+
+I'd welcome 15 minutes to walk you through it. Nothing to sign — just the shape of the deal.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 5. Compass Diversified (CODI)
+
+**To:** Compass Diversified — Acquisitions
+**Subject:** A permanent-capital fit: standardized, leaseable offshore infrastructure
+
+Dear [Name],
+
+CODI's permanent-holding model is the rare structure that can actually capture an asset with a
+50–70 year life across multiple lease cycles — most owners are forced to sell before the
+residual value shows up. The MPSS is that asset: a validated, LR/ABS/DNV-approved offshore host,
+leased and re-let across production, accommodation, floating wind and power.
+
+One hull, adapted by its topside package, on 10–15 year charters — cash-flow like FPSO leasing,
+re-lettability like aircraft. It's a platform you could hold and compound indefinitely.
+
+We're early: a modest **$4M seed** now for a two-year runway, with the first ~$50M hull as the
+build-out step. I'd value 15 minutes to explore whether it fits your permanent-capital book.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 6. DCA Family Office
+
+**To:** DCA Family Office
+**Subject:** From aircraft leasing to marine leasing — the same model, a longer-lived asset
+
+Dear [Name],
+
+DCA's history in aircraft leasing means I barely have to explain the thesis: own a standardized
+asset, lease it on long charters, refinance across lessees. The MPSS is the marine equivalent —
+and where an aircraft lives ~25 years, this hull lives 50–70.
+
+It's a validated, LR/ABS/DNV-approved offshore host, re-let across production, accommodation,
+floating wind ("Turbine Plus"), power and CCS at ~$120k–$350k/day. The AerCap playbook you know,
+applied to an asset with a far longer tail and more re-lease cycles.
+
+We're raising a modest **$4M seed** for a two-year runway to first LOI and a fabrication-ready
+hull — with the ~$50M first hull the natural next step for a leasing-native backer. Could I have
+15 minutes?
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
+
+---
+
+## 7. European Maritime / Shipowning Family Offices (Swiss · Dutch · Scandinavian)
+
+*Use for offices with shipowner heritage — adapt the greeting and the vessel reference per house.*
+
+**To:** [Family Office] — Direct Investments
+**Subject:** A standardized offshore host for a shipowning house
+
+Dear [Name],
+
+Your family knows steel that earns at sea better than any financial sponsor ever will — which is
+why I'm bringing the MPSS to you rather than a generalist. It's a validated, standardized,
+LR/ABS/DNV-approved deepwater host built with ordinary shipyard methods: box construction in
+stiffened mild-steel plate, delivered in ~14 months, effectively motionless in sub-12 m seas.
+
+One hull, chartered like a vessel and re-let across production, tender-assist and workover
+support, accommodation/flotel, floating wind ("Turbine Plus") and power — 10–15 year charters
+against a 50–70 year life. It's the leasing economics your house already understands, on an
+asset with an unusually long tail.
+
+We're raising a modest **$4M seed** for a two-year runway to first charter LOI, with the ~$50M
+first hull the build step for a maritime backer who wants to own steel. I'd value 15 minutes.
+
+Best regards,
+Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com

--- a/outreach/tier-3-direct-invest-family-offices.md
+++ b/outreach/tier-3-direct-invest-family-offices.md
@@ -21,7 +21,7 @@ workover, accommodation, floating wind and power at ~$120k–$350k/day over 10�
 
 The heavy engineering and independent validation are behind us. What we're raising now is a
 modest **$4M seed** for a two-year runway — to first charter LOI and a fabrication-ready first
-hull. It's a small ticket into an asset with a 50–70 year life and a leasing model borrowed
+hull. It's a small ticket into an asset with a 100+ year life and a leasing model borrowed
 straight from aircraft.
 
 Could I have 15 minutes to walk you through it? Nothing to sign — just the case and the numbers.
@@ -39,7 +39,7 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 Dear [Name],
 
 The name says the thesis: preserve and compound over long horizons. The MPSS is built for that
-clock — a validated, LR/ABS/DNV-approved offshore host with a 50–70 year life, leased on 10–15
+clock — a validated, LR/ABS/DNV-approved offshore host with a 100+ year life, leased on 10–15
 year charters and re-let across production, accommodation, floating wind and power as each lease
 rolls. The residual value is a re-lease, not scrap.
 
@@ -66,7 +66,7 @@ premise is turning a bespoke offshore project into a repeatable infrastructure p
 MPSS is validated and classed (Lloyd's, ABS, DNV); the hard part is done.
 
 One standardized hull, re-let across production, tender-assist and workover support,
-accommodation, and floating wind — 10–15 year charters, 50–70 year life. We're raising a modest
+accommodation, and floating wind — 10–15 year charters, 100+ year life. We're raising a modest
 **$4M seed** for a two-year runway to first LOI and fabrication-ready status, with the first
 ~$50M hull the natural next step for backers who want to build from the ground floor.
 
@@ -87,7 +87,7 @@ Dear [Name],
 Given your infrastructure orientation, I wanted to put a genuinely early opportunity in front of
 you. The MPSS is a validated, LR/ABS/DNV-approved deepwater host we lease rather than sell — one
 hull carrying 30,000+ long tons of payload, re-let across production, accommodation, floating wind ("Turbine Plus") and
-power at ~$120k–$350k/day, against a 50–70 year life.
+power at ~$120k–$350k/day, against a 100+ year life.
 
 The engineering and independent validation are complete. We're raising a modest **$4M seed** for
 a two-year runway to first charter LOI and a fabrication-ready first hull — a small ticket into
@@ -108,7 +108,7 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 Dear [Name],
 
 CODI's permanent-holding model is the rare structure that can actually capture an asset with a
-50–70 year life across multiple lease cycles — most owners are forced to sell before the
+100+ year life across multiple lease cycles — most owners are forced to sell before the
 residual value shows up. The MPSS is that asset: a validated, LR/ABS/DNV-approved offshore host,
 leased and re-let across production, accommodation, floating wind and power.
 
@@ -132,7 +132,7 @@ Dear [Name],
 
 DCA's history in aircraft leasing means I barely have to explain the thesis: own a standardized
 asset, lease it on long charters, refinance across lessees. The MPSS is the marine equivalent —
-and where an aircraft lives ~25 years, this hull lives 50–70.
+and where an aircraft lives ~25 years, this hull lives 100+.
 
 It's a validated, LR/ABS/DNV-approved offshore host, re-let across production, accommodation,
 floating wind ("Turbine Plus"), power and CCS at ~$120k–$350k/day. The AerCap playbook you know,
@@ -163,7 +163,7 @@ stiffened mild-steel plate, delivered in ~14 months, effectively motionless in s
 
 One hull, chartered like a vessel and re-let across production, tender-assist and workover
 support, accommodation/flotel, floating wind ("Turbine Plus") and power — 10–15 year charters
-against a 50–70 year life. It's the leasing economics your house already understands, on an
+against a 100+ year life. It's the leasing economics your house already understands, on an
 asset with an unusually long tail.
 
 We're raising a modest **$4M seed** for a two-year runway to first charter LOI, with the ~$50M

--- a/outreach/tier-3-direct-invest-family-offices.md
+++ b/outreach/tier-3-direct-invest-family-offices.md
@@ -86,7 +86,7 @@ Dear [Name],
 
 Given your infrastructure orientation, I wanted to put a genuinely early opportunity in front of
 you. The MPSS is a validated, LR/ABS/DNV-approved deepwater host we lease rather than sell — one
-15,000-tonne hull re-let across production, accommodation, floating wind ("Turbine Plus") and
+hull carrying 30,000+ long tons of payload, re-let across production, accommodation, floating wind ("Turbine Plus") and
 power at ~$120k–$350k/day, against a 50–70 year life.
 
 The engineering and independent validation are complete. We're raising a modest **$4M seed** for

--- a/outreach/tier-3-direct-invest-family-offices.md
+++ b/outreach/tier-3-direct-invest-family-offices.md
@@ -9,20 +9,22 @@ fabrication-ready; nothing larger is on the table in the first call.
 
 ## 1. Tillery Capital Partners
 
-**To:** Tillery Capital Partners
-**Subject:** Getting in early on standardized offshore infrastructure — a $4M seed
+**To:** Chris Weidenhammer — Managing Partner, Tillery Capital
+**Subject:** A durable, contracted, long-hold real asset — a $4M seed
 
-Dear [Name],
+Dear Chris,
 
-Tillery works the lower-middle-market with an infrastructure lean — which is exactly the entry
-point for the MPSS before it becomes a fleet. We've validated and classed (Lloyd's, ABS, DNV) a
-standardized deepwater host that gets leased, not sold: one hull, re-let across production,
-workover, accommodation, floating wind and power at ~$120k–$350k/day over 10–15 year charters.
+Tillery backs durable, cash-generative businesses in the lower-middle-market and holds them —
+family-office structured, no fund clock. The MPSS is that same kind of asset in steel:
+standardized, contracted, and built to outlast everyone who signs the charter.
 
-The heavy engineering and independent validation are behind us. What we're raising now is a
-modest **$4M seed** for a two-year runway — to first charter LOI and a fabrication-ready first
-hull. It's a small ticket into an asset with a 100+ year life and a leasing model borrowed
-straight from aircraft.
+We've validated and classed (Lloyd's, ABS, DNV) a standardized deepwater host that gets leased,
+not sold: one hull, re-let across production, workover, accommodation, floating wind and power at
+~$120k–$350k/day. Built for a fraction of a conventional host and chartered at the rate that host
+commands — durable contracted cash flow on a 100+ year asset.
+
+The heavy engineering is behind us. What we're raising now is a modest **$4M seed** for a
+two-year runway — to first charter LOI and a fabrication-ready first hull.
 
 Could I have 15 minutes to walk you through it? Nothing to sign — just the case and the numbers.
 
@@ -34,7 +36,7 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 ## 2. Preservation Holdings
 
 **To:** Preservation Holdings
-**Subject:** A 50-year asset for long-hold capital — early backing
+**Subject:** A 100-year asset for long-hold capital — early backing
 
 Dear [Name],
 
@@ -125,22 +127,23 @@ Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com
 
 ## 6. DCA Family Office
 
-**To:** DCA Family Office
-**Subject:** From aircraft leasing to marine leasing — the same model, a longer-lived asset
+**To:** Curt Rocca — Managing Partner, DCA Family Office
+**Subject:** Institutional-quality access to a 100-year asset — without the institutional hassle
 
-Dear [Name],
+Dear Curt,
 
-DCA's history in aircraft leasing means I barely have to explain the thesis: own a standardized
-asset, lease it on long charters, refinance across lessees. The MPSS is the marine equivalent —
-and where an aircraft lives ~25 years, this hull lives 100+.
+DCA gives UHNW and tax-sensitive families institutional-quality access without the institutional
+hassle — patient, flexible capital that can hold what a fund clock never could. The MPSS is built
+for exactly that holder.
 
-It's a validated, LR/ABS/DNV-approved offshore host, re-let across production, accommodation,
-floating wind ("Turbine Plus"), power and CCS at ~$120k–$350k/day. The AerCap playbook you know,
-applied to an asset with a far longer tail and more re-lease cycles.
+It's a standardized, LR/ABS/DNV-approved offshore host we lease rather than sell — one hull
+re-let across production, accommodation, floating wind ("Turbine Plus"), power and CCS at
+~$120k–$350k/day, on a 100+ year asset (Lloyd's: no inherent weakness). Own it once and re-let it
+across five or six charter cycles — long-tail, tax-efficient compounding your families are built
+to hold.
 
 We're raising a modest **$4M seed** for a two-year runway to first LOI and a fabrication-ready
-hull — with the ~$50M first hull the natural next step for a leasing-native backer. Could I have
-15 minutes?
+first hull. Could I have 15 minutes?
 
 Best regards,
 Stewart Lang · Seaways MPSS · stewart.lang@seaways-mpss.com


### PR DESCRIPTION
Tailored 15-minute-call invitations for MPSS across three tiers, each
led with the recipient's own precedent and the best-fit use case
(production, workover, tender-assist, accommodation, Turbine Plus wind,
power, CCS, marginal fields). Asks calibrated per target: ~$4M seed for
direct-invest offices, ~$50M first-hull equity or a JV for the large
infrastructure managers and institutional/sovereign arms.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TZ5oBa7gJXHR87fb1q2eoR