### PR TITLE
Add "For Family Offices" investor page with live equity-returns model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ leaseable offshore infrastructure that compresses the timeline from FID to first
 | File | Purpose |
 |------|---------|
 | `index.html` | The full single-page site (hero, the MPSS, the Five S, specs, the model, heritage, leasing, contact). |
+| `day-rates.html` + `day-rates.js` | An editable day-rate leasing model — swap tenants in/out, compare revenue, net and payback; export to CSV. |
+| `invest.html` + `invest.js` | **For Family Offices.** An investor page framing the MPSS as a hard, income-producing real asset, with an interactive equity-returns calculator: type in a check size and see ownership, cash yield, IRR, MOIC and payback compute live, plus a year-by-year distribution schedule and CSV export. |
 | `styles.css` | All styling. Navy / ocean-blue / steel palette; fully responsive. |
-| `main.js`   | Mobile nav toggle and footer year. The site works without JS. |
+| `main.js`   | Mobile nav toggle and footer year. The site works without JS (the calculators need JS). |
 
 ## Running locally
 
@@ -29,8 +31,12 @@ For the `seaways-mpss.com` domain, point the host at this repository / folder.
 
 ## Content notes
 
-- **Contact details** — search `index.html` for `stewart.lang@seaways-mpss.com` and update the
-  email; add phone/address in the `#contact` section as needed.
+- **Contact details** — search `index.html` (and `invest.html`) for `stewart.lang@seaways-mpss.com`
+  and update the email; add phone/address in the `#contact` / `#data-room` sections as needed.
+- **Investor figures** are illustrative placeholders defined in `defaultState()` in `invest.js`
+  (asset cost, leverage, interest, net charter cash flow, hold, residual). Edit there to change the
+  defaults; every field is also editable live in the browser. The page carries a clear disclaimer that
+  the model is for discussion only and is not an offer of securities.
 - **Copy** lives inline in `index.html`, grouped by clearly-commented sections.
 - Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no
   third-party chart images), so they're safe to edit and reuse.

--- a/day-rates.html
+++ b/day-rates.html
@@ -32,6 +32,7 @@
           <li><a href="index.html#specs">Specs</a></li>
           <li><a href="index.html#model">The Model</a></li>
           <li><a href="day-rates.html" aria-current="page">Day Rates</a></li>
+          <li><a href="invest.html">For Family Offices</a></li>
           <li><a href="index.html#contact" class="nav-cta">Contact</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
           <li><a href="#comparison">Comparison</a></li>
           <li><a href="#model">The Model</a></li>
           <li><a href="day-rates.html">Day Rates</a></li>
+          <li><a href="invest.html">For Family Offices</a></li>
           <li><a href="#contact" class="nav-cta">Contact</a></li>
         </ul>
       </nav>
@@ -535,6 +536,16 @@
             <li>Field-life extension</li>
             <li>Redeployable asset value</li>
           </ul>
+        </div>
+
+        <div class="invest-bridge">
+          <div class="invest-bridge-text">
+            <h3>Own the asset behind the lease.</h3>
+            <p>That leaseable, redeployable income stream is also an investable one. For family offices and
+              private capital, the MPSS is a hard, income-producing real asset — model your own equity check
+              and see the cash yield, IRR and payback.</p>
+          </div>
+          <a href="invest.html" class="btn btn-primary">For family offices →</a>
         </div>
       </div>
     </section>

--- a/invest.html
+++ b/invest.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>For Family Offices — Seaways MPSS · A hard asset that pays</title>
+  <meta name="description" content="Seaways MPSS for family offices and private capital: an income-producing, classed real asset. Contracted day-rate cash flow uncorrelated to public markets, hard-asset collateral, and redeployable residual value. Model your own equity check — cash yield, IRR, MOIC and payback — live." />
+  <meta name="theme-color" content="#0a1a2f" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Seaways MPSS — For Family Offices & Private Capital" />
+  <meta property="og:description" content="A hard asset that pays like a bond and compounds like equity. Contracted offshore-infrastructure income, hard-asset collateral, redeployable residual value — modelled live to your own check size." />
+  <meta property="og:url" content="https://seaways-mpss.com/invest.html" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a1a2f'/%3E%3Cpath d='M4 20h24M8 20v-6h16v6M13 14V9h6v5' stroke='%232ea3d9' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
+</head>
+<body>
+  <!-- ===================== HEADER ===================== -->
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a href="index.html#top" class="brand" aria-label="Seaways MPSS home">
+        <svg class="brand-mark" viewBox="0 0 32 32" width="34" height="34" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#0a1a2f"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="brand-text">Seaways<span class="brand-accent"> MPSS</span></span>
+      </a>
+
+      <nav class="site-nav" aria-label="Primary">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul id="nav-menu" class="nav-menu">
+          <li><a href="index.html#about">The MPSS</a></li>
+          <li><a href="index.html#model">The Model</a></li>
+          <li><a href="day-rates.html">Day Rates</a></li>
+          <li><a href="invest.html" aria-current="page">For Family Offices</a></li>
+          <li><a href="#data-room" class="nav-cta">Data Room</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- ===================== HERO ===================== -->
+    <section class="hero invest-hero">
+      <div class="hero-bg" aria-hidden="true">
+        <svg class="hero-platform" viewBox="0 0 1200 520" preserveAspectRatio="xMidYMax meet" role="img" aria-label="Illustration of a Multi-Purpose Semi-Submersible production platform">
+          <defs>
+            <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#dbe5ee"/>
+              <stop offset="1" stop-color="#8ea6bd"/>
+            </linearGradient>
+            <linearGradient id="deckG" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#f2f6fb"/>
+              <stop offset="1" stop-color="#c3d2e2"/>
+            </linearGradient>
+            <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#12507a"/>
+              <stop offset="1" stop-color="#0a2c47"/>
+            </linearGradient>
+          </defs>
+          <rect x="0" y="360" width="1200" height="160" fill="url(#sea)"/>
+          <path d="M0 372 Q 150 362 300 372 T 600 372 T 900 372 T 1200 372" fill="none" stroke="#2ea3d9" stroke-opacity="0.35" stroke-width="2"/>
+          <path d="M0 392 Q 150 384 300 392 T 600 392 T 900 392 T 1200 392" fill="none" stroke="#2ea3d9" stroke-opacity="0.2" stroke-width="2"/>
+          <rect x="358" y="392" width="484" height="34" rx="12" fill="#0e3a5c"/>
+          <rect x="392" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="512" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="642" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="762" y="298" width="46" height="106" rx="6" fill="url(#steel)"/>
+          <rect x="356" y="268" width="488" height="36" rx="6" fill="url(#deckG)"/>
+          <rect x="356" y="264" width="488" height="8" rx="4" fill="#9fb4c8"/>
+          <rect x="392" y="224" width="72" height="44" rx="3" fill="#c9d7e6"/>
+          <rect x="482" y="206" width="82" height="62" rx="3" fill="#dbe6f1"/>
+          <rect x="584" y="232" width="60" height="36" rx="3" fill="#c9d7e6"/>
+          <path d="M662 268 L678 166 L694 268 Z" fill="none" stroke="#aebfd1" stroke-width="4"/>
+          <line x1="670" y1="218" x2="686" y2="218" stroke="#aebfd1" stroke-width="3"/>
+          <line x1="666" y1="243" x2="690" y2="243" stroke="#aebfd1" stroke-width="3"/>
+          <rect x="728" y="220" width="14" height="48" fill="#b9c9d9"/>
+          <circle cx="735" cy="214" r="8" fill="#ff8a3d" opacity="0.85"/>
+          <line x1="378" y1="404" x2="150" y2="500" stroke="#0e3a5c" stroke-width="3" stroke-opacity="0.7"/>
+          <line x1="822" y1="404" x2="1050" y2="500" stroke="#0e3a5c" stroke-width="3" stroke-opacity="0.7"/>
+        </svg>
+      </div>
+
+      <div class="container hero-content">
+        <p class="eyebrow">For Family Offices &amp; Private Capital</p>
+        <h1>A hard asset that pays like a bond<br>and <span class="grad">compounds like equity.</span></h1>
+        <p class="hero-sub">
+          The Seaways MPSS is a validated, independently classed offshore production host — 15,000&nbsp;tonnes of
+          income-producing steel on the water. Leased on multi-year day rates, it throws off
+          <strong>contracted cash flow that has nothing to do with the stock market</strong>, sits on
+          hard-asset collateral, and can be re-deployed to the next field for a second and third life.
+        </p>
+        <div class="hero-actions">
+          <a href="#calculator" class="btn btn-primary">Model your return</a>
+          <a href="#data-room" class="btn btn-ghost">Request the data room</a>
+        </div>
+        <ul class="hero-stats">
+          <li><span class="stat-num">Real asset</span><span class="stat-label">classed steel, not paper</span></li>
+          <li><span class="stat-num">Contracted</span><span class="stat-label">multi-year day-rate income</span></li>
+          <li><span class="stat-num">Uncorrelated</span><span class="stat-label">to public equities</span></li>
+          <li><span class="stat-num">Redeployable</span><span class="stat-label">residual value at exit</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ===================== THESIS ===================== -->
+    <section class="section" id="thesis">
+      <div class="container">
+        <p class="section-eyebrow">The Thesis in One Minute</p>
+        <h2 class="section-title">Everything a patient family balance sheet is built to own.</h2>
+        <p class="lead">
+          Family offices don't chase the market — they buy durable things that pay. The MPSS is exactly that
+          shape of asset: tangible, income-producing, defensively contracted, and long-lived. Four reasons it
+          belongs on a private balance sheet.
+        </p>
+
+        <div class="cards cards-2">
+          <article class="card card-lg">
+            <span class="thesis-ico" aria-hidden="true">⚓</span>
+            <h3>Hard-asset collateral</h3>
+            <p>Your capital sits behind 15,000&nbsp;t of mild-steel hull classed by Lloyd's Register, ABS and DNV —
+              not a covenant, not a brand, not goodwill. If a charter ends, the asset is still there, still
+              classed, and still leaseable to the next field.</p>
+          </article>
+          <article class="card card-lg">
+            <span class="thesis-ico" aria-hidden="true">📈</span>
+            <h3>Contracted, uncorrelated income</h3>
+            <p>Revenue comes from multi-year day-rate charters to offshore operators — cash flow driven by
+              field economics and steel availability, not by equity multiples or rate cycles. A genuine
+              diversifier next to public stocks, credit and real estate.</p>
+          </article>
+          <article class="card card-lg">
+            <span class="thesis-ico" aria-hidden="true">🛡️</span>
+            <h3>Downside built in by design</h3>
+            <p>Tested to a 37.5&nbsp;m survival wave with broken-mooring survival. Single operating draft, deep-draft
+              low motion, huge stability margin. The engineering that keeps it producing in a storm is the same
+              engineering that protects the residual value your capital is secured against.</p>
+          </article>
+          <article class="card card-lg">
+            <span class="thesis-ico" aria-hidden="true">♻️</span>
+            <h3>A second and third life</h3>
+            <p>When one field winds down, the same hull floats off and re-leases — added tiebacks, power,
+              compression, CCS, hydrogen, data centres, accommodation. Optionality that keeps the asset earning
+              far beyond a single charter and supports a real exit value.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== AT A GLANCE ===================== -->
+    <section class="section section-dark" id="at-a-glance">
+      <div class="container">
+        <p class="section-eyebrow light">The Investment at a Glance</p>
+        <h2 class="section-title light">Illustrative shape of a single-asset position.</h2>
+        <p class="lead light">
+          Placeholder figures for discussion — every one is editable in the model below. They describe the
+          economics of one MPSS host leased on a stabilised charter, not an offer.
+        </p>
+
+        <div class="specs-grid invest-specs">
+          <div class="spec"><span class="spec-num">$600<small>M</small></span><span class="spec-label">Indicative all-in asset cost per host</span></div>
+          <div class="spec"><span class="spec-num">~15<small>%</small></span><span class="spec-label">Illustrative unlevered net yield on asset</span></div>
+          <div class="spec"><span class="spec-num">Target<small>2x+</small></span><span class="spec-label">Equity MOIC over a ~10-year hold</span></div>
+          <div class="spec"><span class="spec-num">Multi<small>yr</small></span><span class="spec-label">Day-rate charters underpin the cash flow</span></div>
+          <div class="spec"><span class="spec-num">LR·ABS<small>DNV</small></span><span class="spec-label">Independently classed &amp; endorsed</span></div>
+          <div class="spec"><span class="spec-num">Real<small>asset</small></span><span class="spec-label">Redeployable residual value at exit</span></div>
+        </div>
+
+        <ul class="spec-notes">
+          <li>Income secured against a tangible, classed hull — not a going-concern operating business</li>
+          <li>Returns driven by charter cash flow plus residual value, not by market re-rating</li>
+          <li>Structured for co-investment: preferred equity, SPV co-invest, or sale-leaseback</li>
+          <li>Sponsor alignment through co-investment and standardised, repeatable assets</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ===================== MANDATE FIT ===================== -->
+    <section class="section section-alt" id="fit">
+      <div class="container">
+        <p class="section-eyebrow">Fit With a Family-Office Mandate</p>
+        <h2 class="section-title">Mapped to what you actually screen for.</h2>
+        <p class="lead">
+          The questions a serious private balance sheet asks before it commits — and how leaseable offshore
+          infrastructure answers each one.
+        </p>
+
+        <div class="table-wrap">
+          <table class="matrix">
+            <thead>
+              <tr><th>What you screen for</th><th>The MPSS answer</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Capital preservation</td><td>Hard-asset collateral: a classed steel hull with independent, redeployable residual value</td></tr>
+              <tr><td>Real, current income</td><td>Contracted multi-year day-rate charters — cash yield from year one of hire, not deferred carry</td></tr>
+              <tr><td>Low correlation</td><td>Returns tied to offshore field economics and steel availability, not public-equity or rate cycles</td></tr>
+              <tr><td>Inflation resilience</td><td>A physical, replacement-cost asset; charters can be structured with escalation</td></tr>
+              <tr><td>Downside protection</td><td>Engineered survival margins protect the asset — and the residual value your capital is secured against</td></tr>
+              <tr><td>Direct, tangible ownership</td><td>Own the asset through an SPV — no blind-pool fund, clear line of sight to the steel</td></tr>
+              <tr><td>Manager alignment</td><td>Sponsor co-invests; standardised, repeatable hulls mean known cost, known motions, known build</td></tr>
+              <tr><td>Exit optionality</td><td>Re-lease, sale-leaseback, lease-to-own, or outright sale of a redeployable asset</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== STRUCTURES ===================== -->
+    <section class="section" id="structures">
+      <div class="container">
+        <p class="section-eyebrow">How You Can Come In</p>
+        <h2 class="section-title">Structures that suit a private balance sheet.</h2>
+        <p class="lead">
+          There is no single template. We shape the position around your mandate — income-first, growth-first,
+          or capital-secured — across four common structures.
+        </p>
+
+        <div class="struct-grid">
+          <article class="struct-card">
+            <span class="struct-tag">Income-first</span>
+            <h3>Preferred equity</h3>
+            <p>A fixed preferred return with priority over sponsor equity, secured against the asset. The
+              closest thing to a bond coupon, backed by classed steel rather than a credit rating.</p>
+          </article>
+          <article class="struct-card struct-card-feature">
+            <span class="struct-tag">Balanced</span>
+            <h3>Co-investment SPV</h3>
+            <p>Own a direct, pro-rata slice of a single host through a dedicated special-purpose vehicle.
+              Current cash yield from the charter plus your share of the residual value at exit.</p>
+          </article>
+          <article class="struct-card">
+            <span class="struct-tag">Capital-secured</span>
+            <h3>Sale-leaseback</h3>
+            <p>Acquire the hull and lease it straight back to the operating company on a long charter. You
+              hold the real asset; the operator holds the use. Clean separation of ownership and operation.</p>
+          </article>
+          <article class="struct-card">
+            <span class="struct-tag">Growth</span>
+            <h3>Platform equity</h3>
+            <p>Back the standardisation of the fleet itself — several hulls, staggered charters, a diversified
+              book of leaseable offshore infrastructure with re-deployment optionality across fields.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== CALCULATOR ===================== -->
+    <section class="section section-alt calc-section" id="calculator">
+      <div class="container">
+        <p class="section-eyebrow">Model Your Own Position</p>
+        <h2 class="section-title">Type in your check. Watch it work.</h2>
+        <p class="lead">
+          Set the deal assumptions, then enter the size of the equity you'd write. The model returns your
+          ownership, annual cash yield, projected IRR, money-multiple (MOIC) and payback — live. Every input
+          is editable, saved in this browser, and exportable to a spreadsheet. Illustrative placeholders, not
+          an offer.
+        </p>
+
+        <!-- Assumptions -->
+        <div class="calc-assumptions invest-assumptions">
+          <div class="assume-field">
+            <label for="asset-cost">All-in asset cost</label>
+            <div class="input-money"><span class="prefix">$</span><input type="text" inputmode="numeric" id="asset-cost" class="calc-num" /></div>
+            <span class="assume-hint">Build / lease-in cost of one host.</span>
+          </div>
+          <div class="assume-field">
+            <label for="debt-pct">Debt in capital stack</label>
+            <div class="input-pct"><input type="text" inputmode="decimal" id="debt-pct" class="calc-num" /><span class="suffix">%</span></div>
+            <span class="assume-hint">The rest is equity. 0% = all-equity.</span>
+          </div>
+          <div class="assume-field">
+            <label for="interest-rate">Debt interest rate</label>
+            <div class="input-pct"><input type="text" inputmode="decimal" id="interest-rate" class="calc-num" /><span class="suffix">%</span></div>
+            <span class="assume-hint">Interest-only during the hold.</span>
+          </div>
+          <div class="assume-field">
+            <label for="net-charter">Net charter cash flow / yr</label>
+            <div class="input-money"><span class="prefix">$</span><input type="text" inputmode="numeric" id="net-charter" class="calc-num" /></div>
+            <span class="assume-hint">Day-rate revenue after operating cost.</span>
+          </div>
+          <div class="assume-field">
+            <label for="hold-years">Hold period</label>
+            <div class="input-pct"><input type="text" inputmode="decimal" id="hold-years" class="calc-num" /><span class="suffix">yr</span></div>
+            <span class="assume-hint">Years to exit / redeployment.</span>
+          </div>
+          <div class="assume-field">
+            <label for="residual-pct">Residual value at exit</label>
+            <div class="input-pct"><input type="text" inputmode="decimal" id="residual-pct" class="calc-num" /><span class="suffix">%</span></div>
+            <span class="assume-hint">Asset value at exit, % of cost.</span>
+          </div>
+        </div>
+
+        <!-- Your check -->
+        <div class="check-panel">
+          <label for="your-check" class="check-label">Your equity check</label>
+          <div class="check-row">
+            <div class="input-money check-money"><span class="prefix">$</span><input type="text" inputmode="numeric" id="your-check" class="calc-num" /></div>
+            <div class="check-chips" role="group" aria-label="Preset check sizes">
+              <button type="button" class="chip" data-check="5000000">$5M</button>
+              <button type="button" class="chip" data-check="10000000">$10M</button>
+              <button type="button" class="chip" data-check="25000000">$25M</button>
+              <button type="button" class="chip" data-check="50000000">$50M</button>
+              <button type="button" class="chip" data-check="100000000">$100M</button>
+            </div>
+          </div>
+          <p class="check-note" id="check-note"></p>
+        </div>
+
+        <!-- Headline results -->
+        <div class="result-grid" id="result-grid">
+          <div class="result-card result-card-hero">
+            <span class="result-label">Net IRR</span>
+            <span class="result-num" id="r-irr">—</span>
+            <span class="result-sub">levered, to your equity</span>
+          </div>
+          <div class="result-card">
+            <span class="result-label">Cash yield / yr</span>
+            <span class="result-num" id="r-yield">—</span>
+            <span class="result-sub" id="r-yield-abs">—</span>
+          </div>
+          <div class="result-card">
+            <span class="result-label">Money multiple</span>
+            <span class="result-num" id="r-moic">—</span>
+            <span class="result-sub">total in vs total out</span>
+          </div>
+          <div class="result-card">
+            <span class="result-label">Cash payback</span>
+            <span class="result-num" id="r-payback">—</span>
+            <span class="result-sub">from distributions alone</span>
+          </div>
+          <div class="result-card">
+            <span class="result-label">Your ownership</span>
+            <span class="result-num" id="r-own">—</span>
+            <span class="result-sub" id="r-own-sub">of project equity</span>
+          </div>
+          <div class="result-card">
+            <span class="result-label">Total to you</span>
+            <span class="result-num" id="r-total">—</span>
+            <span class="result-sub">distributions + exit</span>
+          </div>
+        </div>
+
+        <!-- Cumulative chart -->
+        <div class="calc-compare invest-chart-wrap">
+          <h3 class="subhead">Your capital, returned and compounded</h3>
+          <div class="invest-chart" id="invest-chart" aria-hidden="true"></div>
+          <div class="chart-legend">
+            <span class="lg lg-cap">Capital invested</span>
+            <span class="lg lg-dist">Cumulative distributions</span>
+            <span class="lg lg-exit">Exit proceeds</span>
+          </div>
+        </div>
+
+        <!-- Year-by-year -->
+        <div class="table-wrap calc-table-wrap invest-schedule-wrap">
+          <table class="calc-table invest-schedule">
+            <thead>
+              <tr>
+                <th class="col-name">Year</th>
+                <th class="col-calc">Distribution</th>
+                <th class="col-calc">Cumulative</th>
+                <th class="col-calc">Net cash position</th>
+                <th class="col-calc">Return of capital</th>
+              </tr>
+            </thead>
+            <tbody id="schedule-body"><!-- rows injected by JS --></tbody>
+          </table>
+        </div>
+
+        <div class="calc-toolbar invest-toolbar">
+          <div class="calc-tools">
+            <button type="button" id="export-csv" class="btn btn-ghost btn-sm">Export CSV</button>
+            <button type="button" id="reset-all" class="btn btn-ghost btn-sm calc-danger">Reset to defaults</button>
+          </div>
+          <a href="#data-room" class="btn btn-primary btn-sm">These numbers interest me →</a>
+        </div>
+
+        <p class="hull-note calc-disclaimer">
+          Illustrative model for discussion only. Asset cost, leverage, interest, charter cash flow, hold and
+          residual value are placeholder defaults you can edit — they are not offers, projections, quotes or
+          guarantees of return. Debt is modelled as interest-only with principal repaid from exit proceeds.
+          Figures are shown before fund-level fees, tax, mobilisation and transaction costs. Past or modelled
+          performance does not indicate future results. This is not an offer to sell or a solicitation to buy
+          any security.
+        </p>
+      </div>
+    </section>
+
+    <!-- ===================== ALIGNMENT ===================== -->
+    <section class="section" id="alignment">
+      <div class="container">
+        <p class="section-eyebrow">Alignment &amp; Diligence</p>
+        <h2 class="section-title">Built to survive a family office's scrutiny.</h2>
+        <p class="lead">
+          Serious capital diligences the sponsor as hard as the asset. Here is what stands behind both.
+        </p>
+
+        <div class="cards cards-2">
+          <article class="card card-lg">
+            <h3>The asset is independently validated</h3>
+            <ul class="ticks">
+              <li>Classification review by Lloyd's Register, ABS &amp; DNV</li>
+              <li>Design endorsed by Prof. Douglas Faulkner, University of Glasgow</li>
+              <li>Peer-reviewed and tank-tested at 1:100 scale</li>
+              <li>Four decades of engineering behind the five-S design</li>
+            </ul>
+          </article>
+          <article class="card card-lg">
+            <h3>The structure is built for you</h3>
+            <ul class="ticks">
+              <li>Direct asset ownership through a ring-fenced SPV</li>
+              <li>Sponsor co-investment — skin in the same game</li>
+              <li>Transparent reporting on charter, utilisation &amp; cash flow</li>
+              <li>Clear exit paths: re-lease, sale-leaseback or sale</li>
+            </ul>
+          </article>
+        </div>
+
+        <blockquote class="pull-quote">
+          Most alternatives ask a family to underwrite a team and a thesis. This asks you to underwrite a
+          classed steel asset that produces cash and can be sold to the next field. That is the difference
+          between backing a promise and owning a thing that pays.
+        </blockquote>
+      </div>
+    </section>
+
+    <!-- ===================== DATA ROOM / CTA ===================== -->
+    <section class="section section-cta" id="data-room">
+      <div class="container contact-inner">
+        <h2 class="section-title light">Open the data room.</h2>
+        <p class="lead light">
+          If the shape of this fits your mandate, the next step is quiet and simple: we share the diligence
+          pack — the classification record, the reference host economics, the structure and the terms — and we
+          talk. No fund pitch, no blind pool. One asset, one conversation.
+        </p>
+
+        <div class="contact-actions">
+          <a class="btn btn-primary" href="mailto:stewart.lang@seaways-mpss.com?subject=MPSS%20%E2%80%94%20Family%20office%20enquiry&amp;body=We'd%20like%20access%20to%20the%20Seaways%20MPSS%20data%20room.">Request the data room</a>
+          <a class="btn btn-ghost light" href="#calculator">Back to the model</a>
+        </div>
+
+        <ul class="contact-details">
+          <li><span class="c-label">Private enquiries</span><a href="mailto:stewart.lang@seaways-mpss.com?subject=MPSS%20%E2%80%94%20Family%20office%20enquiry">stewart.lang@seaways-mpss.com</a></li>
+          <li><span class="c-label">Web</span><a href="https://seaways-mpss.com/">seaways-mpss.com</a></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <!-- ===================== FOOTER ===================== -->
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#13273d"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>Seaways<span class="brand-accent"> MPSS</span></span>
+      </div>
+      <p class="footer-tag">LANG's MPSS — Simple · Safe · Swift · Size · Saves.</p>
+      <p class="footer-copy">© <span id="year"></span> Seaways MPSS. All rights reserved. Illustrative material — not an offer of securities.</p>
+    </div>
+  </footer>
+
+  <script src="main.js"></script>
+  <script src="invest.js"></script>
+</body>
+</html>

--- a/invest.js
+++ b/invest.js
@@ -1,0 +1,403 @@
+/* =========================================================
+   Seaways MPSS — Family-office equity returns model
+   Dependency-free. Type in a check size; it returns
+   ownership, cash yield, IRR, MOIC, payback and a
+   year-by-year distribution schedule. Editable + CSV.
+   ========================================================= */
+(function () {
+  "use strict";
+
+  var STORE_KEY = "mpss-invest-model-v1";
+
+  /* ---- Default deal (illustrative placeholders) ---- */
+  function defaultState() {
+    return {
+      assetCost: 600000000,   // all-in cost of one host
+      debtPct: 55,            // debt share of the capital stack
+      interestRate: 8,        // annual interest on debt (interest-only)
+      netCharter: 94000000,   // net charter cash flow per year (after opex)
+      holdYears: 10,          // years to exit / redeployment
+      residualPct: 60,        // asset value at exit, % of cost
+      yourCheck: 25000000     // the family office's equity commitment
+    };
+  }
+
+  var state = load() || defaultState();
+
+  function load() {
+    try {
+      var raw = localStorage.getItem(STORE_KEY);
+      if (!raw) return null;
+      var s = JSON.parse(raw);
+      if (!s || typeof s.assetCost === "undefined") return null;
+      return s;
+    } catch (e) { return null; }
+  }
+  function save() {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(state)); } catch (e) {}
+  }
+
+  /* ---- Number helpers ---- */
+  function toNum(v) {
+    if (typeof v === "number") return isFinite(v) ? v : 0;
+    var n = parseFloat(String(v).replace(/[^0-9.\-]/g, ""));
+    return isFinite(n) ? n : 0;
+  }
+  function fmtMoney(n) {
+    n = Math.round(toNum(n));
+    return "$" + n.toLocaleString("en-US");
+  }
+  function fmtShort(n) {
+    n = toNum(n);
+    var abs = Math.abs(n), sign = n < 0 ? "-" : "";
+    if (abs >= 1e9) return sign + "$" + (abs / 1e9).toFixed(2).replace(/\.?0+$/, "") + "B";
+    if (abs >= 1e6) return sign + "$" + (abs / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+    if (abs >= 1e3) return sign + "$" + Math.round(abs / 1e3) + "k";
+    return sign + "$" + Math.round(abs);
+  }
+  function fmtPct(n, dp) {
+    if (!isFinite(n)) return "—";
+    return (n * 100).toFixed(dp == null ? 1 : dp) + "%";
+  }
+  function clampPct(v) { v = toNum(v); return Math.max(0, Math.min(100, v)); }
+
+  /* ---- IRR via bisection over a cash-flow array (annual) ---- */
+  function npv(rate, cfs) {
+    var v = 0;
+    for (var t = 0; t < cfs.length; t++) v += cfs[t] / Math.pow(1 + rate, t);
+    return v;
+  }
+  function irr(cfs) {
+    // Need at least one negative and one positive flow.
+    var hasNeg = false, hasPos = false;
+    for (var i = 0; i < cfs.length; i++) {
+      if (cfs[i] < 0) hasNeg = true;
+      if (cfs[i] > 0) hasPos = true;
+    }
+    if (!hasNeg || !hasPos) return NaN;
+    var lo = -0.9999, hi = 10; // -100% .. +1000%
+    var fLo = npv(lo, cfs), fHi = npv(hi, cfs);
+    if (fLo * fHi > 0) return NaN; // no sign change in range
+    for (var k = 0; k < 200; k++) {
+      var mid = (lo + hi) / 2;
+      var fMid = npv(mid, cfs);
+      if (Math.abs(fMid) < 1e-6) return mid;
+      if (fLo * fMid < 0) { hi = mid; fHi = fMid; }
+      else { lo = mid; fLo = fMid; }
+    }
+    return (lo + hi) / 2;
+  }
+
+  /* ---- Core economics ---- */
+  function compute() {
+    var assetCost = toNum(state.assetCost);
+    var debtPct = clampPct(state.debtPct);
+    var equityTotal = assetCost * (1 - debtPct / 100);
+    var debt = assetCost * (debtPct / 100);
+    var interest = debt * (toNum(state.interestRate) / 100);
+    var hold = Math.max(1, Math.round(toNum(state.holdYears)));
+    var netCharter = toNum(state.netCharter);
+
+    // Project-level levered cash flow to equity, per year.
+    var projLeveredCF = netCharter - interest;
+
+    // Exit: asset residual less debt principal (interest-only => full debt repaid).
+    var residual = assetCost * (toNum(state.residualPct) / 100);
+    var exitEquity = residual - debt;
+
+    // The family office's slice.
+    var check = toNum(state.yourCheck);
+    var ownership = equityTotal > 0 ? check / equityTotal : 0;
+    var yourCF = projLeveredCF * ownership;       // per year
+    var yourExit = exitEquity * ownership;
+    var yourDistTotal = yourCF * hold;
+    var yourTotalOut = yourDistTotal + yourExit;
+
+    var cashYield = check > 0 ? yourCF / check : 0;   // annual cash-on-cash
+    var moic = check > 0 ? yourTotalOut / check : 0;
+    var payback = yourCF > 0 ? check / yourCF : Infinity;
+
+    // Cash-flow vector for IRR: -check at t0, +yourCF y1..hold, +exit at hold.
+    var cfs = [-check];
+    for (var y = 1; y <= hold; y++) {
+      cfs.push(yourCF + (y === hold ? yourExit : 0));
+    }
+    var rate = irr(cfs);
+
+    // Year-by-year schedule for the family office.
+    var schedule = [];
+    var cum = 0;
+    for (var yr = 1; yr <= hold; yr++) {
+      var dist = yourCF + (yr === hold ? yourExit : 0);
+      cum += dist;
+      schedule.push({
+        year: yr,
+        dist: dist,
+        cum: cum,
+        net: cum - check,            // cumulative cash vs. capital in
+        rocPct: check > 0 ? Math.min(1, cum / check) : 0,
+        isExit: yr === hold
+      });
+    }
+
+    return {
+      equityTotal: equityTotal, debt: debt, interest: interest,
+      projLeveredCF: projLeveredCF, residual: residual, exitEquity: exitEquity,
+      check: check, ownership: ownership, yourCF: yourCF, yourExit: yourExit,
+      yourDistTotal: yourDistTotal, yourTotalOut: yourTotalOut,
+      cashYield: cashYield, moic: moic, payback: payback, irr: rate,
+      hold: hold, schedule: schedule
+    };
+  }
+
+  /* ---- DOM refs ---- */
+  var $ = function (id) { return document.getElementById(id); };
+  var inputs = {
+    assetCost: $("asset-cost"),
+    debtPct: $("debt-pct"),
+    interestRate: $("interest-rate"),
+    netCharter: $("net-charter"),
+    holdYears: $("hold-years"),
+    residualPct: $("residual-pct"),
+    yourCheck: $("your-check")
+  };
+  var moneyFields = { assetCost: 1, netCharter: 1, yourCheck: 1 };
+
+  /* ---- Wire inputs ---- */
+  Object.keys(inputs).forEach(function (key) {
+    var el = inputs[key];
+    if (!el) return;
+    el.addEventListener("focus", function () { el.select(); });
+    el.addEventListener("input", function () {
+      state[key] = toNum(el.value);
+      render(false);
+      save();
+    });
+    el.addEventListener("blur", function () { el.value = displayVal(key); });
+  });
+  function displayVal(key) {
+    var v = toNum(state[key]);
+    return moneyFields[key] ? v.toLocaleString("en-US") : String(v);
+  }
+  function fillInputs() {
+    Object.keys(inputs).forEach(function (key) {
+      if (inputs[key]) inputs[key].value = displayVal(key);
+    });
+  }
+
+  /* ---- Check-size chips ---- */
+  Array.prototype.forEach.call(document.querySelectorAll(".chip"), function (chip) {
+    chip.addEventListener("click", function () {
+      state.yourCheck = toNum(chip.dataset.check);
+      if (inputs.yourCheck) inputs.yourCheck.value = displayVal("yourCheck");
+      render(true);
+      save();
+    });
+  });
+
+  /* ---- Toolbar ---- */
+  $("reset-all").addEventListener("click", function () {
+    if (!window.confirm("Reset the model back to the default deal assumptions?")) return;
+    state = defaultState();
+    render(true);
+    save();
+  });
+  $("export-csv").addEventListener("click", exportCsv);
+
+  /* ---- Render ---- */
+  function render(refillInputs) {
+    if (refillInputs) fillInputs();
+    var m = compute();
+
+    // Headline cards
+    $("r-irr").textContent = isFinite(m.irr) ? fmtPct(m.irr, 1) : "—";
+    $("r-yield").textContent = m.check > 0 ? fmtPct(m.cashYield, 1) : "—";
+    $("r-yield-abs").textContent = m.check > 0 ? fmtShort(m.yourCF) + " / yr to you" : "—";
+    $("r-moic").textContent = m.check > 0 ? m.moic.toFixed(2) + "x" : "—";
+    $("r-payback").textContent = isFinite(m.payback) ? m.payback.toFixed(1) + " yr" : "—";
+    $("r-own").textContent = m.check > 0 ? fmtPct(m.ownership, 1) : "—";
+    $("r-own-sub").textContent = "of " + fmtShort(m.equityTotal) + " project equity";
+    $("r-total").textContent = m.check > 0 ? fmtShort(m.yourTotalOut) : "—";
+
+    // Contextual note
+    var note = $("check-note");
+    if (m.check <= 0) {
+      note.textContent = "Enter a check size to model your position.";
+    } else if (m.check > m.equityTotal) {
+      note.textContent = "That's larger than the whole equity ticket (" + fmtShort(m.equityTotal) +
+        ") — you'd anchor the deal, or take the platform. We can size a facility to fit.";
+    } else {
+      note.textContent = "A " + fmtShort(m.check) + " check buys " + fmtPct(m.ownership, 1) +
+        " of the equity in a " + fmtShort(toNum(state.assetCost)) + " asset.";
+    }
+
+    // Negative-return guard styling on the hero card
+    var heroCard = document.querySelector(".result-card-hero");
+    if (heroCard) heroCard.classList.toggle("result-neg", isFinite(m.irr) && m.irr < 0);
+
+    renderSchedule(m);
+    renderChart(m);
+  }
+
+  function renderSchedule(m) {
+    var body = $("schedule-body");
+    body.innerHTML = "";
+    m.schedule.forEach(function (row) {
+      var tr = document.createElement("tr");
+      if (row.isExit) tr.className = "row-exit";
+
+      var yLabel = "Year " + row.year + (row.isExit ? " · exit" : "");
+      tr.appendChild(td(yLabel, "col-name yr-label"));
+      tr.appendChild(td(fmtMoney(row.dist), "calc-calc num"));
+      tr.appendChild(td(fmtMoney(row.cum), "calc-calc num"));
+      tr.appendChild(td(fmtMoney(row.net), "calc-calc num" + (row.net < 0 ? " neg" : " pos")));
+
+      // Return-of-capital mini bar
+      var tdRoc = document.createElement("td");
+      tdRoc.className = "num roc-cell";
+      var track = document.createElement("div");
+      track.className = "roc-track";
+      var bar = document.createElement("div");
+      bar.className = "roc-bar";
+      bar.style.width = (row.rocPct * 100).toFixed(1) + "%";
+      if (row.rocPct >= 1) bar.classList.add("roc-full");
+      track.appendChild(bar);
+      var lbl = document.createElement("span");
+      lbl.className = "roc-lbl";
+      lbl.textContent = (row.rocPct * 100).toFixed(0) + "%";
+      tdRoc.appendChild(track);
+      tdRoc.appendChild(lbl);
+      tr.appendChild(tdRoc);
+
+      body.appendChild(tr);
+    });
+  }
+  function td(text, cls) {
+    var el = document.createElement("td");
+    if (cls) el.className = cls;
+    el.textContent = text;
+    return el;
+  }
+
+  /* ---- Cumulative distributions chart (inline SVG) ---- */
+  function renderChart(m) {
+    var wrap = $("invest-chart");
+    var W = 720, H = 240, padL = 58, padR = 16, padT = 18, padB = 34;
+    var plotW = W - padL - padR, plotH = H - padT - padB;
+
+    var maxCum = m.check;
+    m.schedule.forEach(function (r) { if (r.cum > maxCum) maxCum = r.cum; });
+    if (maxCum <= 0) maxCum = 1;
+
+    var n = m.schedule.length;
+    var xFor = function (yr) { return padL + (n <= 1 ? plotW / 2 : (yr / n) * plotW); };
+    var yFor = function (v) { return padT + plotH - (v / maxCum) * plotH; };
+
+    // Build cumulative distribution area path (start at 0,0).
+    var area = "M " + padL + " " + yFor(0);
+    var line = "M " + padL + " " + yFor(0);
+    m.schedule.forEach(function (r) {
+      var x = xFor(r.year), y = yFor(r.cum);
+      area += " L " + x.toFixed(1) + " " + y.toFixed(1);
+      line += " L " + x.toFixed(1) + " " + y.toFixed(1);
+    });
+    area += " L " + xFor(n) + " " + yFor(0) + " Z";
+
+    // Capital-invested reference line.
+    var capY = yFor(m.check);
+
+    // Gridlines (0, 50%, 100% of max) — labelled in $.
+    var grids = "";
+    [0, 0.5, 1].forEach(function (f) {
+      var gy = padT + plotH - f * plotH;
+      grids += '<line x1="' + padL + '" y1="' + gy.toFixed(1) + '" x2="' + (W - padR) +
+        '" y2="' + gy.toFixed(1) + '" class="grid"/>' +
+        '<text x="' + (padL - 8) + '" y="' + (gy + 4).toFixed(1) +
+        '" class="gtxt" text-anchor="end">' + fmtShort(maxCum * f) + '</text>';
+    });
+
+    // X labels (year 0 and final).
+    var xlabels = '<text x="' + padL + '" y="' + (H - 10) + '" class="gtxt" text-anchor="middle">Y0</text>' +
+      '<text x="' + xFor(n) + '" y="' + (H - 10) + '" class="gtxt" text-anchor="middle">Y' + n + '</text>';
+
+    // Exit marker (last point).
+    var last = m.schedule[n - 1];
+    var exitDot = '<circle cx="' + xFor(n) + '" cy="' + yFor(last.cum) + '" r="5" class="exit-dot"/>';
+
+    var svg =
+      '<svg viewBox="0 0 ' + W + ' ' + H + '" role="img" preserveAspectRatio="xMidYMid meet">' +
+      '<defs><linearGradient id="distFill" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0" stop-color="#2ea3d9" stop-opacity="0.42"/>' +
+      '<stop offset="1" stop-color="#2ea3d9" stop-opacity="0.04"/>' +
+      '</linearGradient></defs>' +
+      grids +
+      '<path d="' + area + '" fill="url(#distFill)"/>' +
+      '<path d="' + line + '" fill="none" class="dist-line"/>' +
+      '<line x1="' + padL + '" y1="' + capY.toFixed(1) + '" x2="' + (W - padR) +
+      '" y2="' + capY.toFixed(1) + '" class="cap-line"/>' +
+      '<text x="' + (W - padR) + '" y="' + (capY - 6).toFixed(1) +
+      '" class="captxt" text-anchor="end">Capital in · ' + fmtShort(m.check) + '</text>' +
+      exitDot +
+      xlabels +
+      '</svg>';
+
+    wrap.innerHTML = svg;
+  }
+
+  /* ---- CSV export ---- */
+  function csvCell(v) {
+    var s = String(v == null ? "" : v);
+    if (/[",\n]/.test(s)) s = '"' + s.replace(/"/g, '""') + '"';
+    return s;
+  }
+  function exportCsv() {
+    var m = compute();
+    var L = [];
+    L.push(["Seaways MPSS — Family-office return model"].map(csvCell).join(","));
+    L.push([].join(","));
+    L.push(["Deal assumptions"].map(csvCell).join(","));
+    L.push(["All-in asset cost", toNum(state.assetCost)].map(csvCell).join(","));
+    L.push(["Debt (% of stack)", clampPct(state.debtPct)].map(csvCell).join(","));
+    L.push(["Interest rate (%)", toNum(state.interestRate)].map(csvCell).join(","));
+    L.push(["Net charter cash flow / yr", toNum(state.netCharter)].map(csvCell).join(","));
+    L.push(["Hold (years)", m.hold].map(csvCell).join(","));
+    L.push(["Residual at exit (%)", toNum(state.residualPct)].map(csvCell).join(","));
+    L.push([].join(","));
+    L.push(["Project equity", Math.round(m.equityTotal)].map(csvCell).join(","));
+    L.push(["Project debt", Math.round(m.debt)].map(csvCell).join(","));
+    L.push(["Exit equity value", Math.round(m.exitEquity)].map(csvCell).join(","));
+    L.push([].join(","));
+    L.push(["Your position"].map(csvCell).join(","));
+    L.push(["Equity check", Math.round(m.check)].map(csvCell).join(","));
+    L.push(["Ownership of equity (%)", (m.ownership * 100).toFixed(2)].map(csvCell).join(","));
+    L.push(["Cash yield / yr (%)", (m.cashYield * 100).toFixed(2)].map(csvCell).join(","));
+    L.push(["Distribution / yr", Math.round(m.yourCF)].map(csvCell).join(","));
+    L.push(["Net IRR (%)", isFinite(m.irr) ? (m.irr * 100).toFixed(2) : ""].map(csvCell).join(","));
+    L.push(["MOIC (x)", m.moic.toFixed(2)].map(csvCell).join(","));
+    L.push(["Cash payback (yr)", isFinite(m.payback) ? m.payback.toFixed(1) : ""].map(csvCell).join(","));
+    L.push(["Exit proceeds to you", Math.round(m.yourExit)].map(csvCell).join(","));
+    L.push(["Total out to you", Math.round(m.yourTotalOut)].map(csvCell).join(","));
+    L.push([].join(","));
+    L.push(["Year", "Distribution", "Cumulative", "Net cash position", "Return of capital (%)"].map(csvCell).join(","));
+    m.schedule.forEach(function (r) {
+      L.push([
+        r.year + (r.isExit ? " (exit)" : ""),
+        Math.round(r.dist), Math.round(r.cum), Math.round(r.net),
+        (r.rocPct * 100).toFixed(0)
+      ].map(csvCell).join(","));
+    });
+
+    var blob = new Blob(["﻿" + L.join("\r\n")], { type: "text/csv;charset=utf-8;" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    a.download = "mpss-family-office-model.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+  }
+
+  /* ---- Go ---- */
+  render(true);
+})();

--- a/styles.css
+++ b/styles.css
@@ -868,3 +868,233 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
   .compare-item { grid-template-columns: 120px 1fr 82px; gap: 10px; }
   .compare-label { font-size: .82rem; }
 }
+
+/* =========================================================
+   Family-office / investor page (invest.html)
+   ========================================================= */
+.invest-hero h1 { font-size: clamp(2rem, 4.8vw, 3.35rem); }
+
+/* Thesis cards */
+.thesis-ico {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px; height: 46px;
+  margin-bottom: 14px;
+  font-size: 1.5rem;
+  line-height: 1;
+  border-radius: 12px;
+  background: var(--bg-tint);
+  border: 1px solid var(--line);
+}
+.invest-specs .spec-num small { color: var(--accent-glow); }
+
+/* Percent / suffix inputs */
+.input-pct { position: relative; display: inline-flex; align-items: center; width: 100%; }
+.input-pct .suffix {
+  position: absolute; right: 12px;
+  color: var(--slate-light); font-size: .9rem; pointer-events: none;
+}
+.input-pct .calc-num { padding-right: 30px; }
+.invest-assumptions { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px 26px; }
+.invest-assumptions .assume-field { min-width: 0; }
+.invest-assumptions .calc-num { max-width: 100%; }
+
+/* Structures */
+.struct-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+.struct-card {
+  position: relative;
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px 24px;
+  box-shadow: var(--shadow-sm);
+}
+.struct-card-feature {
+  border: 2px solid var(--accent);
+  box-shadow: 0 8px 30px rgba(46, 163, 217, .2);
+}
+.struct-tag {
+  display: inline-block;
+  font-size: .72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--accent-deep);
+  background: var(--bg-tint);
+  border-radius: 999px;
+  padding: 4px 12px;
+  margin-bottom: 14px;
+}
+.struct-card h3 { font-size: 1.18rem; color: var(--navy-900); margin-bottom: 10px; }
+.struct-card p { margin: 0; color: var(--slate); font-size: .96rem; }
+
+/* Your-check panel */
+.check-panel {
+  background: linear-gradient(120deg, #0e2846, #14507a);
+  border-radius: var(--radius);
+  padding: 26px 28px;
+  margin-bottom: 24px;
+  box-shadow: var(--shadow-md);
+}
+.check-label {
+  display: block;
+  font-size: .8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--accent-glow);
+  margin-bottom: 12px;
+}
+.check-row { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; }
+.check-money { width: auto; }
+.check-money .calc-num {
+  min-width: 200px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  padding: 12px 14px 12px 26px;
+  border: 0;
+}
+.check-money .prefix { font-size: 1.1rem; left: 12px; }
+.check-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+  font: inherit;
+  font-weight: 600;
+  font-size: .9rem;
+  color: #eaf4fb;
+  background: rgba(255, 255, 255, .1);
+  border: 1px solid rgba(255, 255, 255, .28);
+  border-radius: 999px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background .15s ease, transform .12s ease;
+}
+.chip:hover { background: rgba(255, 255, 255, .2); transform: translateY(-1px); }
+.check-note { margin: 14px 0 0; color: #bcd9ef; font-size: .96rem; }
+
+/* Result cards */
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 16px;
+  margin-bottom: 40px;
+}
+.result-card {
+  grid-column: span 2;
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 22px 22px 20px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.result-card-hero {
+  grid-column: span 6;
+  background: linear-gradient(135deg, #0d2138, #14507a);
+  border: 0;
+  align-items: flex-start;
+}
+.result-card-hero.result-neg { background: linear-gradient(135deg, #3a1512, #6b241d); }
+.result-label {
+  font-size: .74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .07em;
+  color: var(--slate-light);
+}
+.result-card-hero .result-label { color: var(--accent-glow); }
+.result-num {
+  font-size: clamp(1.8rem, 3.2vw, 2.3rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--navy-900);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.result-card-hero .result-num { font-size: clamp(2.6rem, 6vw, 3.8rem); color: #fff; }
+.result-sub { font-size: .84rem; color: var(--slate-light); }
+.result-card-hero .result-sub { color: #a7c8e2; }
+
+/* Chart */
+.invest-chart-wrap { margin-top: 8px; }
+.invest-chart {
+  background: var(--white);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 14px 16px;
+}
+.invest-chart svg { width: 100%; height: auto; display: block; }
+.invest-chart .grid { stroke: var(--line); stroke-width: 1; }
+.invest-chart .gtxt { fill: var(--slate-light); font-size: 11px; font-family: var(--font); font-variant-numeric: tabular-nums; }
+.invest-chart .dist-line { stroke: var(--accent-deep); stroke-width: 2.5; stroke-linejoin: round; stroke-linecap: round; }
+.invest-chart .cap-line { stroke: var(--flare); stroke-width: 2; stroke-dasharray: 6 5; }
+.invest-chart .captxt { fill: var(--flare); font-size: 11px; font-weight: 700; font-family: var(--font); }
+.invest-chart .exit-dot { fill: var(--accent); stroke: #fff; stroke-width: 2; }
+.chart-legend { display: flex; flex-wrap: wrap; gap: 8px 22px; margin-top: 12px; }
+.chart-legend .lg { position: relative; padding-left: 22px; font-size: .86rem; color: var(--slate); }
+.chart-legend .lg::before {
+  content: ""; position: absolute; left: 0; top: 50%; transform: translateY(-50%);
+  width: 14px; height: 3px; border-radius: 2px;
+}
+.chart-legend .lg-cap::before { background: var(--flare); }
+.chart-legend .lg-dist::before { background: var(--accent-deep); }
+.chart-legend .lg-exit::before { background: var(--accent); height: 10px; width: 10px; border-radius: 50%; }
+
+/* Schedule table */
+.invest-schedule-wrap { margin-top: 34px; }
+.invest-schedule { min-width: 640px; }
+.invest-schedule thead th { text-align: right; }
+.invest-schedule thead th.col-name { text-align: left; }
+.invest-schedule .yr-label { font-weight: 600; color: var(--navy-900); }
+.invest-schedule .calc-calc.pos { color: var(--navy-700); }
+.invest-schedule .calc-calc.neg { color: #b4443a; }
+.invest-schedule tr.row-exit td { background: rgba(46, 163, 217, .1) !important; border-top: 2px solid var(--accent); }
+.invest-schedule tr.row-exit .yr-label { color: var(--accent-deep); }
+.roc-cell { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.roc-track { width: 90px; height: 10px; background: var(--bg-tint); border-radius: 5px; overflow: hidden; }
+.roc-bar { height: 100%; background: linear-gradient(90deg, var(--accent-deep), var(--accent)); border-radius: 5px; transition: width .25s ease; }
+.roc-bar.roc-full { background: linear-gradient(90deg, #1c9e6a, #34c98a); }
+.roc-lbl { font-size: .82rem; font-weight: 700; color: var(--slate); min-width: 34px; text-align: right; font-variant-numeric: tabular-nums; }
+
+.invest-toolbar { margin-top: 26px; align-items: center; }
+
+/* Bridge from leasing section -> investor page */
+.invest-bridge {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 34px;
+  padding: 28px 30px;
+  background: linear-gradient(120deg, #0e2846, #14507a);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+}
+.invest-bridge-text { max-width: 680px; }
+.invest-bridge h3 { color: #fff; font-size: 1.3rem; margin-bottom: 8px; }
+.invest-bridge p { margin: 0; color: #c4d9ec; }
+.invest-bridge .btn { flex: none; }
+
+@media (max-width: 900px) {
+  .struct-grid { grid-template-columns: 1fr 1fr; }
+  .invest-assumptions { grid-template-columns: 1fr 1fr; }
+  .result-grid { grid-template-columns: repeat(4, 1fr); }
+  .result-card { grid-column: span 2; }
+  .result-card-hero { grid-column: span 4; }
+}
+@media (max-width: 620px) {
+  .struct-grid { grid-template-columns: 1fr; }
+  .invest-assumptions { grid-template-columns: 1fr; }
+  .result-grid { grid-template-columns: 1fr 1fr; }
+  .result-card, .result-card-hero { grid-column: span 2; }
+  .check-money .calc-num { min-width: 0; width: 100%; }
+  .check-money { width: 100%; }
+}


### PR DESCRIPTION
Adds invest.html + invest.js: an investor-facing page that frames the
Seaways MPSS as a hard, income-producing real asset for family offices
and private capital — hard-asset collateral, contracted uncorrelated
income, engineered downside protection, and redeployable residual value.

The centrepiece is an interactive equity-returns calculator: the visitor
types in their own equity check and the model computes ownership, annual
cash yield, levered net IRR (bisection-solved), MOIC, cash payback and a
year-by-year distribution schedule with a cumulative-distributions chart —
all editable, saved to localStorage, and exportable to CSV. Includes
mandate-fit matrix, four investment structures, alignment/diligence, and
a data-room CTA. All figures are illustrative placeholders with a clear
"not an offer of securities" disclaimer.

Wires the new page into the primary nav (index.html, day-rates.html) and
adds a bridge CTA from the leasing section into the investor page.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ANSNPiaNSNAeNgEbyGyeG9