### PR TITLE
Add Founding Investor Memorandum brochure page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ leaseable offshore infrastructure that compresses the timeline from FID to first
 | `index.html` | The full single-page site (hero, the MPSS, the Five S, specs, the model, heritage, leasing, contact). |
 | `day-rates.html` + `day-rates.js` | An editable day-rate leasing model — swap tenants in/out, compare revenue, net and payback; export to CSV. |
 | `invest.html` + `invest.js` | **For Family Offices.** An investor page framing the MPSS as a hard, income-producing real asset, with an interactive equity-returns calculator: type in a check size and see ownership, cash yield, IRR, MOIC and payback compute live, plus a year-by-year distribution schedule and CSV export. |
+| `memo.html` + `memo.css` | **Founding Investor Memorandum.** A brochure-style, print-friendly memorandum: cover page, numbered sections (opportunity, problem, solution, market, business model, illustrative economics, heritage, founding round & use of proceeds, the ask) and a full disclaimer. Reuses `styles.css`; `memo.css` adds the brochure layer. |
 | `styles.css` | All styling. Navy / ocean-blue / steel palette; fully responsive. |
 | `main.js`   | Mobile nav toggle and footer year. The site works without JS (the calculators need JS). |
 
@@ -38,6 +39,9 @@ For the `seaways-mpss.com` domain, point the host at this repository / folder.
   defaults; every field is also editable live in the browser. The page carries a clear disclaimer that
   the model is for discussion only and is not an offer of securities.
 - **Copy** lives inline in `index.html`, grouped by clearly-commented sections.
+- **Founding-round amount** — the memorandum's "The Ask" shows a placeholder `$[__]M`
+  (marked `data-illustrative` in `memo.html`). Replace it with the real figure before sharing.
+  The use-of-proceeds percentages and milestone phases in the same section are illustrative too.
 - Specs, the Five S and the lifecycle/driver tables are hand-built in HTML/CSS (no
   third-party chart images), so they're safe to edit and reuse.
 - Key figures (15,000 t payload, 8,100 m² deck, 2M bbl SWIS storage, 37.5 m survival wave,

--- a/day-rates.html
+++ b/day-rates.html
@@ -33,6 +33,7 @@
           <li><a href="index.html#model">The Model</a></li>
           <li><a href="day-rates.html" aria-current="page">Day Rates</a></li>
           <li><a href="invest.html">For Family Offices</a></li>
+          <li><a href="memo.html">Memorandum</a></li>
           <li><a href="index.html#contact" class="nav-cta">Contact</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
           <li><a href="#model">The Model</a></li>
           <li><a href="day-rates.html">Day Rates</a></li>
           <li><a href="invest.html">For Family Offices</a></li>
+          <li><a href="memo.html">Memorandum</a></li>
           <li><a href="#contact" class="nav-cta">Contact</a></li>
         </ul>
       </nav>

--- a/invest.html
+++ b/invest.html
@@ -36,6 +36,7 @@
           <li><a href="index.html#model">The Model</a></li>
           <li><a href="day-rates.html">Day Rates</a></li>
           <li><a href="invest.html" aria-current="page">For Family Offices</a></li>
+          <li><a href="memo.html">Memorandum</a></li>
           <li><a href="#data-room" class="nav-cta">Data Room</a></li>
         </ul>
       </nav>

--- a/memo.css
+++ b/memo.css
@@ -1,0 +1,312 @@
+/* =========================================================
+   Seaways MPSS — Founding Investor Memorandum
+   Brochure layer on top of styles.css.
+   Cover, numbered sections, callouts, print-friendly.
+   Palette inherited: deep navy / ocean blue / steel.
+   ========================================================= */
+
+:root {
+  --memo-maxw: 940px;
+  --gold: #c9a24b;
+  --gold-deep: #a5822f;
+}
+
+/* ---- Document shell ---- */
+.memo {
+  background: var(--bg-alt);
+}
+.memo .sheet {
+  max-width: var(--memo-maxw);
+  margin: 0 auto;
+  background: var(--white);
+  box-shadow: var(--shadow-md);
+}
+.memo .sheet + .sheet { margin-top: 28px; }
+
+.memo-pad {
+  padding: 72px clamp(28px, 6vw, 84px);
+}
+
+/* ---- Confidential ribbon under the header ---- */
+.memo-ribbon {
+  background: var(--navy-900);
+  color: #cde3f2;
+  font-size: .78rem;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+.memo-ribbon .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding-top: 9px;
+  padding-bottom: 9px;
+}
+.memo-ribbon .rib-mark { color: var(--accent-glow); font-weight: 600; }
+.memo-ribbon .rib-conf { color: #9fc3dc; }
+
+/* ============ COVER ============ */
+.memo .sheet.memo-cover {
+  position: relative;
+  overflow: hidden;
+  color: #eaf3fa;
+  background:
+    radial-gradient(120% 80% at 82% -10%, rgba(46,163,217,.28), transparent 60%),
+    linear-gradient(160deg, var(--navy-900) 0%, var(--navy-700) 55%, #0e3255 100%);
+}
+.memo-cover .memo-pad { padding-top: 88px; padding-bottom: 88px; }
+.cover-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-size: .82rem; letter-spacing: .22em; text-transform: uppercase;
+  color: var(--accent-glow);
+  margin: 0 0 26px;
+}
+.cover-eyebrow::before {
+  content: ""; width: 34px; height: 1px; background: var(--accent-glow); opacity: .7;
+}
+.memo-cover h1 {
+  font-size: clamp(2.3rem, 5.2vw, 3.7rem);
+  line-height: 1.05;
+  margin: 0 0 8px;
+  color: #fff;
+}
+.memo-cover .cover-sub-title {
+  font-size: clamp(1.05rem, 2.4vw, 1.4rem);
+  font-weight: 500;
+  color: #bcd6e8;
+  margin: 0 0 34px;
+}
+.memo-cover .cover-sub-title .grad {
+  background: linear-gradient(90deg, var(--accent-glow), #8fd6f5);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.cover-lede {
+  max-width: 60ch;
+  font-size: 1.1rem;
+  color: #d6e6f2;
+  border-left: 3px solid var(--accent);
+  padding-left: 20px;
+  margin: 0 0 44px;
+}
+.cover-five-s {
+  display: flex; flex-wrap: wrap; gap: 10px;
+  margin: 0 0 46px; padding: 0; list-style: none;
+}
+.cover-five-s li {
+  font-size: .82rem; letter-spacing: .12em; text-transform: uppercase;
+  padding: 7px 15px; border-radius: 999px;
+  border: 1px solid rgba(143,214,245,.35);
+  color: #d6ecf7;
+}
+.cover-five-s li b { color: #fff; font-weight: 700; }
+
+.cover-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px 32px;
+  border-top: 1px solid rgba(143,214,245,.24);
+  padding-top: 28px;
+}
+.cover-meta .cm-k {
+  display: block; font-size: .72rem; letter-spacing: .16em; text-transform: uppercase;
+  color: #86b4d2; margin-bottom: 5px;
+}
+.cover-meta .cm-v { display: block; color: #eaf3fa; font-weight: 600; font-size: 1rem; }
+
+/* ============ SECTION NUMBERING ============ */
+.memo-section + .memo-section { border-top: 1px solid var(--line); }
+.memo-kicker {
+  display: flex; align-items: baseline; gap: 14px;
+  margin: 0 0 18px;
+}
+.memo-kicker .k-num {
+  font-size: .95rem; font-weight: 700; letter-spacing: .04em;
+  color: var(--accent-deep);
+  font-variant-numeric: tabular-nums;
+}
+.memo-kicker .k-line { flex: 1; height: 1px; background: var(--line); }
+.memo-kicker .k-tag {
+  font-size: .78rem; letter-spacing: .18em; text-transform: uppercase; color: var(--slate-light);
+}
+.memo-section h2 {
+  font-size: clamp(1.5rem, 3.2vw, 2.05rem);
+  color: var(--navy-900);
+  margin: 0 0 16px;
+  max-width: 24ch;
+}
+.memo-section > .memo-pad > p,
+.memo-lead {
+  font-size: 1.06rem; color: var(--slate); max-width: 68ch;
+}
+.memo-lead { margin-top: 0; }
+.memo-section .body-copy p { color: var(--slate); max-width: 68ch; }
+
+/* ---- Executive at-a-glance strip ---- */
+.memo-glance {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin: 34px 0 8px;
+}
+.memo-glance .g-cell {
+  background: var(--white);
+  padding: 22px 20px;
+}
+.memo-glance .g-num {
+  display: block; font-size: 1.7rem; font-weight: 800; color: var(--navy-900);
+  letter-spacing: -0.02em; line-height: 1.1;
+}
+.memo-glance .g-num small { font-size: .95rem; font-weight: 700; color: var(--accent-deep); margin-left: 2px; }
+.memo-glance .g-lbl { display: block; font-size: .86rem; color: var(--slate-light); margin-top: 6px; }
+
+/* ---- Numbered highlight list ---- */
+.memo-points { list-style: none; margin: 28px 0 0; padding: 0; display: grid; gap: 18px; }
+.memo-points li {
+  display: grid; grid-template-columns: 40px 1fr; gap: 16px; align-items: start;
+}
+.memo-points .mp-n {
+  width: 34px; height: 34px; border-radius: 9px;
+  display: grid; place-items: center;
+  background: var(--bg-tint); color: var(--accent-deep);
+  font-weight: 800; font-size: .95rem;
+}
+.memo-points h4 { margin: 3px 0 4px; color: var(--navy-900); font-size: 1.05rem; }
+.memo-points p { margin: 0; color: var(--slate); font-size: .98rem; }
+
+/* ---- Two-column problem/solution ---- */
+.memo-duo {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 22px; margin-top: 30px;
+}
+.memo-duo .duo-col {
+  border: 1px solid var(--line); border-radius: var(--radius); padding: 24px;
+  background: var(--bg-alt);
+}
+.memo-duo .duo-col.duo-hot {
+  background: linear-gradient(180deg, #f2f9fd, #fff);
+  border-color: #bfe1f2;
+}
+.memo-duo h4 {
+  font-size: .82rem; letter-spacing: .14em; text-transform: uppercase; margin: 0 0 14px;
+}
+.memo-duo .duo-col h4 { color: var(--slate-light); }
+.memo-duo .duo-hot h4 { color: var(--accent-deep); }
+.memo-duo ul { margin: 0; padding-left: 0; list-style: none; display: grid; gap: 11px; }
+.memo-duo li { position: relative; padding-left: 26px; color: var(--slate); font-size: .97rem; }
+.memo-duo li::before {
+  content: ""; position: absolute; left: 0; top: 8px;
+  width: 8px; height: 8px; border-radius: 50%; background: var(--slate-light);
+}
+.memo-duo .duo-hot li::before { background: var(--accent); }
+
+/* ---- Pull quote ---- */
+.memo-quote {
+  margin: 40px 0 8px; padding: 30px 34px;
+  border-left: 4px solid var(--accent);
+  background: var(--navy-900);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: #eaf3fa;
+  font-size: 1.22rem; line-height: 1.45; font-weight: 500;
+}
+.memo-quote cite { display: block; margin-top: 14px; font-size: .9rem; font-style: normal; color: #8fd6f5; }
+
+/* ---- Data table ---- */
+.memo-table { width: 100%; border-collapse: collapse; margin-top: 26px; font-size: .96rem; }
+.memo-table thead th {
+  text-align: left; background: var(--navy-900); color: #eaf3fa;
+  padding: 13px 16px; font-size: .82rem; letter-spacing: .06em; text-transform: uppercase;
+}
+.memo-table thead th:first-child { border-radius: var(--radius-sm) 0 0 0; }
+.memo-table thead th:last-child { border-radius: 0 var(--radius-sm) 0 0; }
+.memo-table td { padding: 13px 16px; border-bottom: 1px solid var(--line); color: var(--slate); vertical-align: top; }
+.memo-table tr:last-child td { border-bottom: 0; }
+.memo-table td:first-child { color: var(--navy-800); font-weight: 600; width: 38%; }
+.memo-table tbody tr:nth-child(even) td { background: var(--bg-alt); }
+
+/* ---- Use-of-proceeds bars ---- */
+.uop { margin-top: 28px; display: grid; gap: 16px; }
+.uop-row { display: grid; grid-template-columns: 180px 1fr 56px; gap: 16px; align-items: center; }
+.uop-label { font-weight: 600; color: var(--navy-800); font-size: .96rem; }
+.uop-track { height: 12px; border-radius: 999px; background: var(--bg-tint); overflow: hidden; }
+.uop-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--accent-deep), var(--accent)); }
+.uop-pct { text-align: right; font-weight: 700; color: var(--navy-900); font-variant-numeric: tabular-nums; }
+
+/* ---- Milestone timeline ---- */
+.memo-timeline { margin-top: 30px; list-style: none; padding: 0; display: grid; gap: 0; }
+.memo-timeline li {
+  position: relative; padding: 0 0 26px 34px; border-left: 2px solid var(--line);
+}
+.memo-timeline li:last-child { border-left-color: transparent; padding-bottom: 0; }
+.memo-timeline li::before {
+  content: ""; position: absolute; left: -8px; top: 2px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--white); border: 3px solid var(--accent);
+}
+.memo-timeline .tl-phase { display: block; font-weight: 700; color: var(--navy-900); }
+.memo-timeline .tl-when { font-size: .8rem; letter-spacing: .1em; text-transform: uppercase; color: var(--accent-deep); }
+.memo-timeline .tl-body { margin: 4px 0 0; color: var(--slate); font-size: .97rem; }
+
+/* ---- The ask card ---- */
+.memo-ask {
+  margin-top: 34px;
+  display: grid; grid-template-columns: 1.1fr 1fr; gap: 0;
+  border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow-sm);
+}
+.memo-ask .ask-main {
+  background: linear-gradient(155deg, var(--navy-900), var(--navy-600));
+  color: #eaf3fa; padding: 32px;
+}
+.memo-ask .ask-main h3 { color: #fff; font-size: 1.3rem; margin: 0 0 10px; }
+.memo-ask .ask-main p { color: #cfe4f2; margin: 0 0 20px; font-size: .98rem; }
+.memo-ask .ask-figure { font-size: 2.4rem; font-weight: 800; color: #fff; letter-spacing: -0.02em; }
+.memo-ask .ask-figure small { font-size: 1rem; font-weight: 600; color: var(--accent-glow); }
+.memo-ask .ask-side { background: var(--bg-alt); padding: 32px; display: grid; gap: 16px; align-content: start; }
+.memo-ask .ask-side .as-row { display: flex; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--line); padding-bottom: 12px; }
+.memo-ask .ask-side .as-row:last-child { border-bottom: 0; padding-bottom: 0; }
+.memo-ask .ask-side .as-k { color: var(--slate-light); font-size: .92rem; }
+.memo-ask .ask-side .as-v { color: var(--navy-900); font-weight: 700; text-align: right; }
+
+/* ---- Signature / contact block ---- */
+.memo-sign {
+  margin-top: 8px;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 28px; align-items: end;
+}
+.memo-sign .sign-name { font-size: 1.15rem; font-weight: 700; color: var(--navy-900); margin: 0; }
+.memo-sign .sign-role { color: var(--slate-light); font-size: .92rem; margin: 2px 0 0; }
+.memo-sign .sign-cta { justify-self: end; }
+
+/* ---- Disclaimer ---- */
+.memo .sheet.memo-disclaimer {
+  background: var(--navy-900); color: #9fc3dc;
+}
+.memo-disclaimer .memo-pad { padding-top: 40px; padding-bottom: 48px; }
+.memo-disclaimer h3 { color: #cde3f2; font-size: .82rem; letter-spacing: .16em; text-transform: uppercase; margin: 0 0 14px; }
+.memo-disclaimer p { font-size: .84rem; line-height: 1.7; color: #90b6d2; max-width: none; margin: 0 0 12px; }
+.memo-disclaimer p:last-child { margin-bottom: 0; }
+
+/* ============ RESPONSIVE ============ */
+@media (max-width: 760px) {
+  .memo-pad { padding: 46px 22px; }
+  .memo-duo { grid-template-columns: 1fr; }
+  .memo-ask { grid-template-columns: 1fr; }
+  .memo-sign { grid-template-columns: 1fr; }
+  .memo-sign .sign-cta { justify-self: start; }
+  .uop-row { grid-template-columns: 120px 1fr 48px; gap: 10px; }
+  .memo-ribbon .container { font-size: .68rem; }
+}
+
+/* ============ PRINT (brochure export) ============ */
+@media print {
+  .site-header, .memo-ribbon, .site-footer, .sign-cta { display: none !important; }
+  body, .memo { background: #fff; }
+  .memo .sheet { box-shadow: none; max-width: none; margin: 0; }
+  .memo .sheet + .sheet { margin-top: 0; }
+  .memo-section, .memo-cover { page-break-inside: avoid; break-inside: avoid; }
+  .memo-cover { page-break-after: always; }
+  .memo-quote, .memo-ask, .memo-cover { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .memo-pad { padding: 40px 30px; }
+}

--- a/memo.html
+++ b/memo.html
@@ -1,0 +1,522 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Founding Investor Memorandum — Seaways MPSS</title>
+  <meta name="description" content="The Founding Investor Memorandum for Seaways MPSS — LANG's validated, independently classed Multi-Purpose Semi-Submersible. The opportunity, the asset, the market, the business model, the founding round and the ask, in one brochure." />
+  <meta name="theme-color" content="#0a1a2f" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Founding Investor Memorandum — Seaways MPSS" />
+  <meta property="og:description" content="A validated, classed deepwater production host, turned into leaseable offshore infrastructure. The founding-round investment memorandum for Seaways MPSS." />
+  <meta property="og:url" content="https://seaways-mpss.com/memo.html" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="memo.css" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a1a2f'/%3E%3Cpath d='M4 20h24M8 20v-6h16v6M13 14V9h6v5' stroke='%232ea3d9' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
+</head>
+<body class="memo">
+  <!-- ===================== HEADER ===================== -->
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a href="index.html#top" class="brand" aria-label="Seaways MPSS home">
+        <svg class="brand-mark" viewBox="0 0 32 32" width="34" height="34" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#0a1a2f"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="brand-text">Seaways<span class="brand-accent"> MPSS</span></span>
+      </a>
+
+      <nav class="site-nav" aria-label="Primary">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul id="nav-menu" class="nav-menu">
+          <li><a href="index.html#about">The MPSS</a></li>
+          <li><a href="index.html#model">The Model</a></li>
+          <li><a href="day-rates.html">Day Rates</a></li>
+          <li><a href="invest.html">For Family Offices</a></li>
+          <li><a href="memo.html" aria-current="page">Memorandum</a></li>
+          <li><a href="#the-ask" class="nav-cta">The Ask</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ===================== CONFIDENTIAL RIBBON ===================== -->
+  <div class="memo-ribbon">
+    <div class="container">
+      <span class="rib-mark">Founding Investor Memorandum</span>
+      <span class="rib-conf">Private &amp; Confidential · Not an offer of securities</span>
+    </div>
+  </div>
+
+  <main>
+
+    <!-- ===================== COVER ===================== -->
+    <section class="sheet memo-cover">
+      <div class="memo-pad">
+        <p class="cover-eyebrow">LANG's MPSS · Multi-Purpose Semi-Submersible</p>
+        <h1>Founding Investor Memorandum</h1>
+        <p class="cover-sub-title">Turning the deepwater host from a bespoke project into
+          <span class="grad">leaseable offshore infrastructure.</span></p>
+
+        <p class="cover-lede">
+          Seaways MPSS is a validated, independently classed production host built with proven
+          ship-building technology. This memorandum sets out the opportunity for founding investors:
+          to capitalise the platform that converts a four-decade, class-endorsed design into a fleet of
+          standardised, income-producing hulls leased to deepwater operators.
+        </p>
+
+        <ul class="cover-five-s">
+          <li><b>Simple</b></li>
+          <li><b>Safe</b></li>
+          <li><b>Swift</b></li>
+          <li><b>Size</b></li>
+          <li><b>Saves</b></li>
+        </ul>
+
+        <div class="cover-meta">
+          <div><span class="cm-k">Prepared for</span><span class="cm-v">Founding investors &amp; strategic partners</span></div>
+          <div><span class="cm-k">Asset class</span><span class="cm-v">Real assets · offshore infrastructure</span></div>
+          <div><span class="cm-k">Instrument</span><span class="cm-v">Founding equity (illustrative)</span></div>
+          <div><span class="cm-k">Status</span><span class="cm-v">For discussion only</span></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== 01 · EXECUTIVE SUMMARY ===================== -->
+    <section class="sheet memo-section" id="summary">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">01</span><span class="k-line"></span><span class="k-tag">Executive Summary</span>
+        </div>
+        <h2>A product where the industry only has projects.</h2>
+        <p class="memo-lead">
+          Every deepwater development engineers a new floating host from scratch — a multi-year, multi-billion
+          dollar bottleneck that sits directly between a discovery and its first barrel. The MPSS replaces that
+          bespoke project with a validated standard host: one classed hull, adapted by its topside package,
+          available to lease before final investment decision. It is the difference between building a project
+          and owning a product.
+        </p>
+
+        <div class="memo-glance">
+          <div class="g-cell"><span class="g-num">15,000<small>t</small></span><span class="g-lbl">Deck payload on a large, stable, open deck</span></div>
+          <div class="g-cell"><span class="g-num">~14<small>mo</small></span><span class="g-lbl">Estimated standardised hull delivery</span></div>
+          <div class="g-cell"><span class="g-num">LR·ABS<small>DNV</small></span><span class="g-lbl">Independently classed &amp; endorsed</span></div>
+          <div class="g-cell"><span class="g-num">40<small>yrs</small></span><span class="g-lbl">Of engineering, tank-testing &amp; review</span></div>
+        </div>
+
+        <ol class="memo-points">
+          <li>
+            <span class="mp-n">1</span>
+            <div>
+              <h4>The pain is universal and expensive</h4>
+              <p>Between host selection and first production, operators carry years of schedule risk and billions
+                in committed capital before host risk is even settled.</p>
+            </div>
+          </li>
+          <li>
+            <span class="mp-n">2</span>
+            <div>
+              <h4>The design already exists and is validated</h4>
+              <p>The five-S MPSS has been analysed, tank-tested, peer-reviewed and reviewed for classification by
+                Lloyd's Register, ABS and DNV — the risky R&amp;D is behind it, not ahead of it.</p>
+            </div>
+          </li>
+          <li>
+            <span class="mp-n">3</span>
+            <div>
+              <h4>The business model is leasing, not selling</h4>
+              <p>A standardised hull is leaseable inventory. Multi-year day-rate charters throw off contracted,
+                uncorrelated cash flow; the redeployable hull retains hard-asset residual value.</p>
+            </div>
+          </li>
+          <li>
+            <span class="mp-n">4</span>
+            <div>
+              <h4>Founding capital converts design into fleet</h4>
+              <p>This round funds the first standardised host to a shipyard-ready package and stands up the
+                leasing platform — the step that turns a validated drawing into a contracted, earning asset.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- ===================== 02 · THE PROBLEM ===================== -->
+    <section class="sheet memo-section" id="problem">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">02</span><span class="k-line"></span><span class="k-tag">The Problem</span>
+        </div>
+        <h2>Deepwater value is won or lost between host selection and first oil.</h2>
+        <p class="memo-lead">
+          Every deepwater project runs the same gauntlet. The stretch from <strong>FID to First Production</strong>
+          — Select, Define/FEED, FID, Execute — is the "kill zone" where operators bleed schedule and capital. The
+          root cause is that the host itself is re-invented every single time.
+        </p>
+
+        <div class="memo-duo">
+          <div class="duo-col">
+            <h4>The conventional path</h4>
+            <ul>
+              <li>A new host engineered around every field</li>
+              <li>Long, custom FEED &amp; risk-reduction cycle</li>
+              <li>Heavy long-lead procurement</li>
+              <li>Bespoke, engineering-intensive fabrication</li>
+              <li>Billions committed at FID before host risk is settled</li>
+              <li>Revenue delayed by host delivery</li>
+            </ul>
+          </div>
+          <div class="duo-col duo-hot">
+            <h4>The MPSS path</h4>
+            <ul>
+              <li>A validated standard host — classed and known</li>
+              <li>Known hull, known motions, known fabrication</li>
+              <li>The host becomes leaseable inventory before FID</li>
+              <li>Repeatable, predictable build</li>
+              <li>Lease structure reduces upfront capital exposure</li>
+              <li>Faster availability accelerates first oil</li>
+            </ul>
+          </div>
+        </div>
+
+        <blockquote class="memo-quote">
+          The conventional model designs a new host around every field. The MPSS reverses it — standard host
+          first, field-specific topsides second. That is the difference between a product and a project.
+        </blockquote>
+      </div>
+    </section>
+
+    <!-- ===================== 03 · THE SOLUTION ===================== -->
+    <section class="sheet memo-section" id="solution">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">03</span><span class="k-line"></span><span class="k-tag">The Solution</span>
+        </div>
+        <h2>Not new technology — proven technology, applied properly.</h2>
+        <p class="memo-lead">
+          The Multi-Purpose Semi-Submersible uses standard ship-building methods: uniform box construction in
+          stiffened mild-steel plate — a continuous ring pontoon, box columns and a buoyant deck box with
+          right-angle joints that are simple to weld and easy to inspect. Less complex than conventional semis,
+          with excellent structural continuity, and adapted to any mission by its topside package.
+        </p>
+
+        <ol class="memo-points">
+          <li><span class="mp-n">S</span><div><h4>Simple</h4><p>Modular, panel-line fabrication in common shipyard practice. Standard mild steel, a single operating draft, simple ballast and trim.</p></div></li>
+          <li><span class="mp-n">S</span><div><h4>Safe</h4><p>A massive reserve of buoyancy and watertight subdivision. Tested to a 37.5&nbsp;m (123&nbsp;ft) storm wave — no water on deck, broken-mooring survival.</p></div></li>
+          <li><span class="mp-n">S</span><div><h4>Swift</h4><p>A modular design means a hull in about 14 months; prefabricated topsides skid on before deck assembly for fast turnaround.</p></div></li>
+          <li><span class="mp-n">S</span><div><h4>Size</h4><p>In the ocean, bigger is better — more stable, more deck, more storage, reconfigurable. Ample margin for steel catenary risers and dry trees.</p></div></li>
+          <li><span class="mp-n">S</span><div><h4>Saves</h4><p>Low initial cost, low maintenance, low operating cost through standardised box construction — plus high residual value.</p></div></li>
+        </ol>
+
+        <table class="memo-table">
+          <thead>
+            <tr><th>Hull attribute</th><th>Conventional twin-pontoon FPU</th><th>LANG's MPSS</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Pontoon form</td><td>Twin ship-form pontoons</td><td>Continuous ring pontoon</td></tr>
+            <tr><td>Construction</td><td>Bespoke, engineering-intensive</td><td>Standardised mild-steel box, panel-line built</td></tr>
+            <tr><td>Operating draft</td><td>Changes to a survival draft in heavy seas</td><td>Single deep operating draft — constant production</td></tr>
+            <tr><td>Deck &amp; motion</td><td>Truss-supported, reacts to surface waves</td><td>Large open deck, low heave from deep-draft damping</td></tr>
+            <tr><td>Onboard storage</td><td>Typically none — needs an FPSO or tanker</td><td>Up to 2&nbsp;M&nbsp;bbl in the SWIS configuration</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- ===================== 04 · MARKET & WHY NOW ===================== -->
+    <section class="sheet memo-section" id="market">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">04</span><span class="k-line"></span><span class="k-tag">Market &amp; Why Now</span>
+        </div>
+        <h2>A standard host meets a market that keeps re-building bespoke ones.</h2>
+        <p class="memo-lead">
+          Deepwater remains one of the largest sources of new barrels, and every project still commissions a
+          one-off host. The same standardised, low-motion hull also answers a widening set of offshore missions
+          beyond oil &amp; gas — which is where a leaseable platform compounds.
+        </p>
+
+        <ol class="memo-points">
+          <li><span class="mp-n">◆</span><div><h4>Deepwater production &amp; tiebacks</h4><p>The core market: a low-motion host that strengthens the SCR / riser / cable case and carries 15,000&nbsp;t of topsides on an open deck.</p></div></li>
+          <li><span class="mp-n">◆</span><div><h4>Storage &amp; FPSO-class duty</h4><p>Up to 2&nbsp;M&nbsp;bbl of onboard storage in the SWIS configuration — FPSO capability without a bespoke conversion.</p></div></li>
+          <li><span class="mp-n">◆</span><div><h4>The energy transition</h4><p>Second and third lives in power, compression, CCS, hydrogen, accommodation and construction support as fields and mandates evolve.</p></div></li>
+        </ol>
+
+        <blockquote class="memo-quote">
+          The window is the standardisation itself: the first operator to lease a validated, classed host — rather
+          than fund another one from a blank sheet — resets the cost and schedule benchmark for the whole basin.
+        </blockquote>
+      </div>
+    </section>
+
+    <!-- ===================== 05 · THE BUSINESS MODEL ===================== -->
+    <section class="sheet memo-section" id="business">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">05</span><span class="k-line"></span><span class="k-tag">The Business Model</span>
+        </div>
+        <h2>Leaseable offshore infrastructure — not a one-off build.</h2>
+        <p class="memo-lead">
+          For deepwater, the host hull is effectively long-lead equipment. The MPSS converts it from a custom
+          project item into available leased infrastructure. A premium lease rate can be paid for by accelerated
+          revenue alone — if first oil is pulled forward even by months.
+        </p>
+
+        <div class="memo-duo">
+          <div class="duo-col duo-hot">
+            <h4>Flexible commercial structures</h4>
+            <ul>
+              <li>Time-charter &amp; bareboat lease</li>
+              <li>Joint venture &amp; risk-share</li>
+              <li>Lease-to-own and outright sale</li>
+              <li>Lease-after-lease redeployment</li>
+            </ul>
+          </div>
+          <div class="duo-col">
+            <h4>A premium rate, justified by more than CAPEX</h4>
+            <ul>
+              <li>Earlier first production &amp; reduced FEED uncertainty</li>
+              <li>Reduced fabrication and riser / cable-fatigue risk</li>
+              <li>Easier topside expansion &amp; field-life extension</li>
+              <li>Redeployable asset value at the end of a charter</li>
+            </ul>
+          </div>
+        </div>
+
+        <p class="memo-lead" style="margin-top:26px">
+          Because the hull is standardised and redeployable, a single asset can earn across multiple fields and
+          missions over its life. That is the engine behind a durable, compounding platform rather than a single
+          project return.
+        </p>
+      </div>
+    </section>
+
+    <!-- ===================== 06 · ILLUSTRATIVE ECONOMICS ===================== -->
+    <section class="sheet memo-section" id="economics">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">06</span><span class="k-line"></span><span class="k-tag">Illustrative Economics</span>
+        </div>
+        <h2>The shape of a single reference host.</h2>
+        <p class="memo-lead">
+          Placeholder figures for discussion — the economics of one MPSS host leased on a stabilised charter.
+          They are not an offer, quote or projection; every input is editable in the live
+          <a href="invest.html#calculator">returns model</a>.
+        </p>
+
+        <div class="memo-glance">
+          <div class="g-cell"><span class="g-num">$600<small>M</small></span><span class="g-lbl">Indicative all-in asset cost per host</span></div>
+          <div class="g-cell"><span class="g-num">~15<small>%</small></span><span class="g-lbl">Illustrative unlevered net yield on asset</span></div>
+          <div class="g-cell"><span class="g-num">2x<small>+</small></span><span class="g-lbl">Target equity MOIC over a ~10-year hold</span></div>
+          <div class="g-cell"><span class="g-num">60<small>%</small></span><span class="g-lbl">Illustrative redeployable residual at exit</span></div>
+        </div>
+
+        <table class="memo-table">
+          <thead><tr><th>What investors screen for</th><th>The MPSS answer</th></tr></thead>
+          <tbody>
+            <tr><td>Capital preservation</td><td>Hard-asset collateral — a classed steel hull with independent, redeployable residual value</td></tr>
+            <tr><td>Real, current income</td><td>Contracted multi-year day-rate charters — cash yield from year one of hire</td></tr>
+            <tr><td>Low correlation</td><td>Returns tied to offshore field economics and steel availability, not equity multiples or rate cycles</td></tr>
+            <tr><td>Inflation resilience</td><td>A physical, replacement-cost asset; charters can be structured with escalation</td></tr>
+            <tr><td>Exit optionality</td><td>Re-lease, sale-leaseback, lease-to-own, or outright sale of a redeployable asset</td></tr>
+          </tbody>
+        </table>
+
+        <p class="body-copy" style="margin-top:22px; font-size:.9rem; color:var(--slate-light)">
+          Figures are illustrative placeholders for discussion only — not offers, projections, quotes or guarantees
+          of return. See the full disclaimer at the foot of this memorandum.
+        </p>
+      </div>
+    </section>
+
+    <!-- ===================== 07 · HERITAGE & VALIDATION ===================== -->
+    <section class="sheet memo-section" id="heritage">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">07</span><span class="k-line"></span><span class="k-tag">Heritage &amp; Validation</span>
+        </div>
+        <h2>Four decades of engineering, independently endorsed.</h2>
+        <p class="memo-lead">
+          The MPSS was first proposed in 1980 by Craig Lang, drawing on deepwater tension-leg-platform mooring
+          engineering. Since then its principles have been analysed, tank-tested, classed and published in the
+          peer-reviewed literature — so a founding investor underwrites execution, not unproven science.
+        </p>
+
+        <div class="memo-duo">
+          <div class="duo-col duo-hot">
+            <h4>Independent endorsement</h4>
+            <ul>
+              <li>Classification review by Lloyd's Register, ABS &amp; DNV</li>
+              <li>Design endorsed by Prof. Douglas Faulkner, University of Glasgow</li>
+              <li>Peer-reviewed: "Design Evaluation of a Multi-Purpose Semisubmersible"</li>
+              <li>Certification covering primary structure, stability, mooring &amp; ballast</li>
+            </ul>
+          </div>
+          <div class="duo-col">
+            <h4>Tested &amp; analysed</h4>
+            <ul>
+              <li>Hydrodynamic behaviour &amp; motions</li>
+              <li>Structural strength &amp; fatigue life</li>
+              <li>Intact &amp; damaged stability and moorings</li>
+              <li>1:100-scale tank testing; doctoral research at Glasgow &amp; Newcastle</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== 08 · THE FOUNDING ROUND ===================== -->
+    <section class="sheet memo-section" id="round">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">08</span><span class="k-line"></span><span class="k-tag">The Founding Round</span>
+        </div>
+        <h2>What founding capital builds.</h2>
+        <p class="memo-lead">
+          The founding round capitalises the platform to carry a validated design across the last, decisive gap:
+          from a class-endorsed drawing to a shipyard-ready, charter-backed first host — and the leasing company
+          that owns it. Allocations below are illustrative and for discussion.
+        </p>
+
+        <div class="uop">
+          <div class="uop-row">
+            <span class="uop-label">Engineering &amp; class package</span>
+            <span class="uop-track"><span class="uop-fill" style="width:35%"></span></span>
+            <span class="uop-pct">35%</span>
+          </div>
+          <div class="uop-row">
+            <span class="uop-label">Commercial &amp; charter origination</span>
+            <span class="uop-track"><span class="uop-fill" style="width:25%"></span></span>
+            <span class="uop-pct">25%</span>
+          </div>
+          <div class="uop-row">
+            <span class="uop-label">Shipyard &amp; supply-chain readiness</span>
+            <span class="uop-track"><span class="uop-fill" style="width:20%"></span></span>
+            <span class="uop-pct">20%</span>
+          </div>
+          <div class="uop-row">
+            <span class="uop-label">Platform, SPV &amp; legal formation</span>
+            <span class="uop-track"><span class="uop-fill" style="width:12%"></span></span>
+            <span class="uop-pct">12%</span>
+          </div>
+          <div class="uop-row">
+            <span class="uop-label">Working capital &amp; contingency</span>
+            <span class="uop-track"><span class="uop-fill" style="width:8%"></span></span>
+            <span class="uop-pct">8%</span>
+          </div>
+        </div>
+
+        <h3 class="subhead" style="margin-top:34px; color:var(--navy-900); font-size:1.05rem; letter-spacing:.02em">Path to a contracted first host</h3>
+        <ol class="memo-timeline">
+          <li>
+            <span class="tl-when">Phase 1</span>
+            <span class="tl-phase">Platform &amp; package</span>
+            <p class="tl-body">Stand up the leasing entity; take the reference host to a shipyard-ready engineering and class package.</p>
+          </li>
+          <li>
+            <span class="tl-when">Phase 2</span>
+            <span class="tl-phase">Anchor charter</span>
+            <p class="tl-body">Originate a lead operator and structure the first multi-year day-rate charter against a defined field.</p>
+          </li>
+          <li>
+            <span class="tl-when">Phase 3</span>
+            <span class="tl-phase">Build &amp; finance</span>
+            <p class="tl-body">Close asset-level financing into a ring-fenced SPV; commence standardised hull fabrication (~14&nbsp;months).</p>
+          </li>
+          <li>
+            <span class="tl-when">Phase 4</span>
+            <span class="tl-phase">On hire &amp; repeat</span>
+            <p class="tl-body">First host on charter and earning; the platform repeats the standardised build for the next field.</p>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- ===================== 09 · THE ASK ===================== -->
+    <section class="sheet memo-section" id="the-ask">
+      <div class="memo-pad">
+        <div class="memo-kicker">
+          <span class="k-num">09</span><span class="k-line"></span><span class="k-tag">The Ask</span>
+        </div>
+        <h2>Back the standardisation of the deepwater host.</h2>
+        <p class="memo-lead">
+          We are inviting a small group of founding investors and strategic partners to capitalise the platform
+          and the first host. The instrument and amount below are illustrative placeholders — the actual terms are
+          shaped with founding investors in the data room.
+        </p>
+
+        <div class="memo-ask">
+          <div class="ask-main">
+            <h3>Founding round</h3>
+            <p>Founding equity to fund the first standardised host to a shipyard-ready, charter-backed position
+              and to stand up the leasing platform behind it.</p>
+            <div class="ask-figure">$<span data-illustrative>[__]</span>M <small>illustrative</small></div>
+          </div>
+          <div class="ask-side">
+            <div class="as-row"><span class="as-k">Instrument</span><span class="as-v">Founding equity</span></div>
+            <div class="as-row"><span class="as-k">Use of proceeds</span><span class="as-v">Package · charter · platform</span></div>
+            <div class="as-row"><span class="as-k">Sponsor alignment</span><span class="as-v">Co-investment</span></div>
+            <div class="as-row"><span class="as-k">Structure</span><span class="as-v">Ring-fenced SPV per host</span></div>
+            <div class="as-row"><span class="as-k">Next step</span><span class="as-v">Data-room access</span></div>
+          </div>
+        </div>
+
+        <div class="memo-sign">
+          <div>
+            <p class="sign-name">Stewart Lang</p>
+            <p class="sign-role">Seaways MPSS · founder contact</p>
+            <p class="sign-role"><a href="mailto:stewart.lang@seaways-mpss.com?subject=MPSS%20%E2%80%94%20Founding%20investor%20enquiry">stewart.lang@seaways-mpss.com</a></p>
+          </div>
+          <a class="btn btn-primary sign-cta" href="mailto:stewart.lang@seaways-mpss.com?subject=MPSS%20%E2%80%94%20Founding%20investor%20enquiry&amp;body=We'd%20like%20to%20discuss%20the%20Seaways%20MPSS%20founding%20round%20and%20access%20the%20data%20room.">Request the data room</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== DISCLAIMER ===================== -->
+    <section class="sheet memo-disclaimer">
+      <div class="memo-pad">
+        <h3>Important notice</h3>
+        <p>
+          This Founding Investor Memorandum is provided on a private and confidential basis for discussion only.
+          It is not an offer to sell, or a solicitation of an offer to buy, any security or interest, and it does
+          not constitute investment, legal, tax or financial advice. Any offer, if made, would be made solely
+          through definitive documentation to eligible investors in permitted jurisdictions.
+        </p>
+        <p>
+          All figures — including asset cost, yield, MOIC, hold period, residual value, use-of-proceeds
+          allocations and the founding-round amount — are illustrative placeholders for discussion. They are not
+          offers, projections, quotes, valuations or guarantees of return, and actual results may differ
+          materially. Modelled or past performance does not indicate future results. Specifications, classification
+          status, timelines and heritage are drawn from Seaways Engineering source material and remain subject to
+          verification and independent diligence.
+        </p>
+        <p>
+          Recipients should rely only on the definitive documentation and their own advisers, and should treat the
+          contents of this memorandum as confidential.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <!-- ===================== FOOTER ===================== -->
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
+          <rect width="32" height="32" rx="7" fill="#13273d"/>
+          <path d="M4 21h24M8 21v-7h16v7M13 14V8h6v6" stroke="#2ea3d9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>Seaways<span class="brand-accent"> MPSS</span></span>
+      </div>
+      <p class="footer-tag">LANG's MPSS — Simple · Safe · Swift · Size · Saves.</p>
+      <p class="footer-copy">© <span id="year"></span> Seaways MPSS. All rights reserved. Private &amp; confidential — not an offer of securities.</p>
+    </div>
+  </footer>
+
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Add memo.html + memo.css: a brochure-style, print-friendly Founding
Investor Memorandum for Seaways MPSS. Reuses the existing navy/ocean
design system and adds a brochure layer (cover, confidential ribbon,
numbered sections, callouts, data tables, use-of-proceeds bars, milestone
timeline, two-tone "Ask" card, and full disclaimer).

Sections: executive summary, the problem (FID-to-first-oil kill zone),
the solution (five-S MPSS + hull comparison), market & why now, the
business model (leasing), illustrative economics, heritage & validation,
the founding round (use of proceeds + milestones) and the ask.

All financials stay illustrative placeholders with the same disclaimers
the site already uses; the founding-round amount is a clearly-marked
[__] placeholder. Add a "Memorandum" nav link across index/invest/
day-rates and document the page in README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WAsu9UJyvT6jaXpf8ZQaPw